### PR TITLE
Implement basic layer editor

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "ini": "^5.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -2078,6 +2079,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ini": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/is-extglob": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "ini": "^5.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,9 +1,16 @@
 .container {
   padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
 }
-textarea {
-  width: 100%;
-  font-family: monospace;
+.editor {
+  flex: 1;
+  overflow: auto;
+  margin-top: 1rem;
+}
+.buttons {
+  margin-top: 1rem;
 }
 .status {
   margin-left: 1rem;

--- a/client/src/LayerEditor.css
+++ b/client/src/LayerEditor.css
@@ -1,0 +1,40 @@
+.layer-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.layer-header,
+.layer-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 40px;
+  gap: 0.5rem;
+  align-items: center;
+}
+.layer-header {
+  font-weight: bold;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #ccc;
+}
+.layer-row {
+  padding: 0.25rem 0;
+}
+.key-input,
+.value-input {
+  width: 100%;
+  padding: 0.25rem;
+  border-radius: 4px;
+  border: 1px solid #666;
+  background: #fff;
+  color: #000;
+}
+.remove-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #c00;
+  font-size: 1rem;
+}
+.add-btn {
+  margin-top: 0.5rem;
+  align-self: flex-start;
+}

--- a/client/src/LayerEditor.jsx
+++ b/client/src/LayerEditor.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import './LayerEditor.css';
+
+export default function LayerEditor({ layers, onChange, onAdd, onRemove }) {
+  return (
+    <div className="layer-editor">
+      <div className="layer-header">
+        <span className="col-key">Layer</span>
+        <span className="col-value">Path</span>
+        <span className="col-actions" />
+      </div>
+      {layers.map((layer, index) => (
+        <div className="layer-row" key={index}>
+          <input
+            className="key-input"
+            value={layer.key}
+            onChange={e => onChange(index, e.target.value, layer.value)}
+          />
+          <input
+            className="value-input"
+            value={layer.value}
+            onChange={e => onChange(index, layer.key, e.target.value)}
+          />
+          <button className="remove-btn" onClick={() => onRemove(layer.key)}>✕</button>
+        </div>
+      ))}
+      <button className="add-btn" onClick={onAdd}>Add Layer</button>
+    </div>
+  );
+}

--- a/client/src/LayersAgent.js
+++ b/client/src/LayersAgent.js
@@ -1,0 +1,33 @@
+export function listLayers(data) {
+  return Object.entries(data.Layers || {}).map(([key, value]) => ({ key, value }));
+}
+
+export function updateLayer(data, index, newKey, newValue) {
+  const keys = Object.keys(data.Layers || {});
+  const oldKey = keys[index];
+  if (!data.Layers) data.Layers = {};
+  if (oldKey && oldKey !== newKey) {
+    delete data.Layers[oldKey];
+  }
+  data.Layers[newKey] = newValue;
+}
+
+export function addLayer(data) {
+  if (!data.Layers) data.Layers = {};
+  const newKey = findNextKey(data);
+  data.Layers[newKey] = '';
+  return newKey;
+}
+
+function findNextKey(data) {
+  const keys = Object.keys(data.Layers).map(k => parseInt(k, 10)).sort((a, b) => a - b);
+  let next = 0;
+  while (keys.includes(next)) next += 1;
+  return String(next).padStart(2, '0');
+}
+
+export function removeLayer(data, key) {
+  if (data.Layers) {
+    delete data.Layers[key];
+  }
+}

--- a/client/src/ParserAgent.js
+++ b/client/src/ParserAgent.js
@@ -1,0 +1,9 @@
+import ini from 'ini';
+
+export function parseIni(text) {
+  return ini.parse(text);
+}
+
+export function stringifyIni(data) {
+  return ini.stringify(data);
+}


### PR DESCRIPTION
## Summary
- add ParserAgent using the `ini` package
- create LayersAgent helper functions
- implement LayerEditor component for editing layer entries
- refactor App to parse INI data and show a modern layer editor
- update styling for full-height layout
- install `ini` package

## Testing
- `npm run lint --prefix client`
- `npm run build --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6866b3746310832f96380be11278532e