### PR TITLE
Preserve uploaded file newline style

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,17 +9,19 @@ function App() {
   const [iniData, setIniData] = useState(null);
   const [layers, setLayers] = useState([]);
   const [fileName, setFileName] = useState('mappingfile.ini');
+  const [newline, setNewline] = useState('\n');
   const [status, setStatus] = useState('');
 
   const handleFileChange = async e => {
     const file = e.target.files[0];
     if (!file) return;
     try {
-      const data = await openFile(file);
-      const parsed = parseIni(data);
+      const { text, newline } = await openFile(file);
+      const parsed = parseIni(text);
       setIniData(parsed);
       setLayers(listLayers(parsed));
       setFileName(file.name);
+      setNewline(newline);
       setStatus(`Loaded ${file.name}`);
     } catch (err) {
       console.error(err);
@@ -29,7 +31,7 @@ function App() {
 
   const download = () => {
     if (!iniData) return;
-    const text = stringifyIni(iniData);
+    const text = stringifyIni(iniData, newline);
     exportFile(text, fileName);
   };
 

--- a/client/src/FileAgent.js
+++ b/client/src/FileAgent.js
@@ -1,7 +1,16 @@
 export function openFile(file) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => resolve(reader.result);
+    reader.onload = () => {
+      const text = reader.result;
+      let newline = '\n';
+      if (/\r\n/.test(text)) {
+        newline = '\r\n';
+      } else if (/\r/.test(text)) {
+        newline = '\r';
+      }
+      resolve({ text, newline });
+    };
     reader.onerror = () => reject(reader.error);
     reader.readAsText(file);
   });

--- a/client/src/ParserAgent.js
+++ b/client/src/ParserAgent.js
@@ -4,9 +4,9 @@ export function parseIni(text) {
   return ini.parse(text);
 }
 
-export function stringifyIni(data) {
+export function stringifyIni(data, newline = '\n') {
   const text = ini.stringify(data);
-  const lines = text.split('\n');
+  const lines = text.split(/\r?\n/);
   let inLayers = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -27,5 +27,5 @@ export function stringifyIni(data) {
       lines[i] = `${key.trim()}=${val}`;
     }
   }
-  return lines.join('\n');
+  return lines.join(newline);
 }


### PR DESCRIPTION
## Summary
- keep newline metadata when uploading `.ini` files
- pass newline style through ParserAgent so downloads match

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866baed30e8832fb23ee32391f31489