### PR TITLE
Preserve whitespace around equals on export

### DIFF
--- a/client/src/ParserAgent.js
+++ b/client/src/ParserAgent.js
@@ -5,7 +5,7 @@ export function parseIni(text) {
 }
 
 export function stringifyIni(data, newline = '\n') {
-  const text = ini.stringify(data);
+  const text = ini.stringify(data, { whitespace: true });
   const lines = text.split(/\r?\n/);
   let inLayers = false;
   for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
## Summary
- ensure ini entries maintain spaces around `=` when exporting

## Testing
- `npm run lint`
- `npm install` in server & client and `npm start` (server)

------
https://chatgpt.com/codex/tasks/task_e_6866bd3bb600832fae41423a4d912fa7