### PR TITLE
Fix spacing for Internal section when exporting INI

### DIFF
--- a/client/src/ParserAgent.js
+++ b/client/src/ParserAgent.js
@@ -8,15 +8,23 @@ export function stringifyIni(data, newline = '\n') {
   const text = ini.stringify(data, { whitespace: true });
   const lines = text.split(/\r?\n/);
   let inLayers = false;
+  let inInternal = false;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const trimmed = line.trim();
     if (trimmed === '[Layers]') {
       inLayers = true;
+      inInternal = false;
+      continue;
+    }
+    if (trimmed === '[Internal]') {
+      inInternal = true;
+      inLayers = false;
       continue;
     }
     if (trimmed.startsWith('[')) {
       inLayers = false;
+      inInternal = false;
     }
     if (inLayers && /^\d{2}\s*=/.test(line)) {
       const [key, ...rest] = line.split('=');
@@ -24,6 +32,10 @@ export function stringifyIni(data, newline = '\n') {
       if (!val.startsWith('"')) {
         val = `"${val}"`;
       }
+      lines[i] = `${key.trim()}=${val}`;
+    } else if (inInternal && /=/.test(line)) {
+      const [key, ...rest] = line.split('=');
+      const val = rest.join('=').trim();
       lines[i] = `${key.trim()}=${val}`;
     }
   }


### PR DESCRIPTION
## Summary
- ensure `stringifyIni` keeps the `[Internal]` key formatting intact

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866c3013c30832fb46dce536e8606f4