### PR TITLE
Fix stray blank lines in exported INI

### DIFF
--- a/client/src/ParserAgent.js
+++ b/client/src/ParserAgent.js
@@ -6,7 +6,17 @@ export function parseIni(text) {
 
 export function stringifyIni(data, newline = '\n') {
   const text = ini.stringify(data, { whitespace: true });
-  const lines = text.split(/\r?\n/);
+  const rawLines = text.split(/\r?\n/);
+  // remove blank lines inserted before section headers
+  const lines = [];
+  for (const line of rawLines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('[') && lines.length && lines[lines.length - 1].trim() === '') {
+      lines.pop();
+    }
+    lines.push(line);
+  }
+
   let inLayers = false;
   let inInternal = false;
   for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
## Summary
- clean up ParserAgent.stringifyIni to drop blank lines before section headers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866c600b3a0832fa4cd7b07e86b32b3