### PR TITLE
Add session persistence in INI editor

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -3,6 +3,10 @@
 
 This web app lets you edit NEVION iPath `.ini` mapping files directly in your browser. Open the page, upload an `.ini` file and download the edited version when you're done.
 
+The editor automatically restores the last loaded file and any edits using the browser's Cache Storage. Refreshing the page resumes your previous session.
+
+Upload a new file at any time to start over; the cached session is cleared when a new file is loaded or when the browser cache is emptied.
+
 ## Development
 
 The project is based on React + Vite with ESLint configured. The usual Vite commands are available:

--- a/client/src/SessionAgent.js
+++ b/client/src/SessionAgent.js
@@ -1,0 +1,31 @@
+const CACHE_NAME = 'mappy-session';
+const SESSION_KEY = 'session';
+
+export async function loadSession() {
+  if (!('caches' in window)) return null;
+  const cache = await caches.open(CACHE_NAME);
+  const response = await cache.match(SESSION_KEY);
+  if (!response) return null;
+  const text = await response.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    await cache.delete(SESSION_KEY);
+    return null;
+  }
+}
+
+export async function saveSession(data) {
+  if (!('caches' in window)) return;
+  const cache = await caches.open(CACHE_NAME);
+  const resp = new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  await cache.put(SESSION_KEY, resp);
+}
+
+export async function clearSession() {
+  if (!('caches' in window)) return;
+  const cache = await caches.open(CACHE_NAME);
+  await cache.delete(SESSION_KEY);
+}


### PR DESCRIPTION
## Summary
- persist loaded file and edits in Cache Storage
- automatically restore previous session on reload
- reset when a new file is uploaded
- document the new behaviour

## Testing
- `npm install` within `client`
- `npm run lint` within `client`


------
https://chatgpt.com/codex/tasks/task_e_6866cdf4503c832f95b18090481bbf17