### PR TITLE
Fix persistence clearing

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -5,7 +5,7 @@ This web app lets you edit NEVION iPath `.ini` mapping files directly in your br
 
 The editor automatically restores the last loaded file and any edits using the browser's Cache Storage. Refreshing the page resumes your previous session.
 
-Upload a new file at any time to start over; the cached session is cleared when a new file is loaded or when the browser cache is emptied.
+Upload a new file at any time to start over; the stored session is cleared when a new file is loaded or when the browser cache is cleared through your browser settings.
 
 ## Development
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,7 +27,7 @@ function App() {
         setStatus(`Restored ${name}`);
       } catch (err) {
         console.error(err);
-        clearSession();
+        await clearSession();
       }
     })();
   }, []);


### PR DESCRIPTION
## Summary
- keep session data in Cache Storage
- restore README note that clearing browser cache resets the session
- await clearSession when an invalid session is found

## Testing
- `npm install` in both client and server
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866d2fdb5e8832f9ea0a78876d42076