### PR TITLE
Add layer tab navigation UI

### DIFF
--- a/client/src/LayerPanel.css
+++ b/client/src/LayerPanel.css
@@ -1,0 +1,38 @@
+.layer-panel {
+  padding: 0.5rem 0;
+}
+
+.layer-path {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.layer-path .path-input {
+  flex: 1;
+  padding: 0.25rem;
+  border: 1px solid #666;
+  border-radius: 4px;
+}
+
+.layer-section {
+  margin-bottom: 1rem;
+}
+
+.layer-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.layer-section li {
+  padding: 0.25rem 0;
+}
+
+.remove-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: #c00;
+}

--- a/client/src/LayerPanel.jsx
+++ b/client/src/LayerPanel.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import './LayerPanel.css';
+
+export default function LayerPanel({ layer, targets, sources, onPathChange, onRemove }) {
+  if (!layer) return null;
+  return (
+    <div className="layer-panel">
+      <div className="layer-path">
+        <label>Layer {layer.key}</label>
+        <input
+          className="path-input"
+          value={layer.value}
+          onChange={e => onPathChange(layer.key, e.target.value)}
+        />
+        {onRemove && (
+          <button className="remove-btn" onClick={() => onRemove(layer.key)}>Delete</button>
+        )}
+      </div>
+      <div className="layer-section">
+        <h3>Targets</h3>
+        <ul>
+          {targets.map(t => (
+            <li key={t.key}>{t.key} = {t.value}</li>
+          ))}
+        </ul>
+      </div>
+      <div className="layer-section">
+        <h3>Sources</h3>
+        <ul>
+          {sources.map(s => (
+            <li key={s.key}>{s.key} = {s.value}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/src/LayerTabs.css
+++ b/client/src/LayerTabs.css
@@ -1,0 +1,24 @@
+.layer-tabs {
+  display: flex;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 0.5rem;
+}
+
+.layer-tabs .tab {
+  padding: 0.5rem 1rem;
+  margin-right: 0.25rem;
+  background: #f9f9f9;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+}
+
+.layer-tabs .tab.active {
+  border-bottom-color: #646cff;
+  font-weight: bold;
+  background: #fff;
+}
+
+.layer-tabs .tab.add {
+  font-weight: bold;
+}

--- a/client/src/LayerTabs.jsx
+++ b/client/src/LayerTabs.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import './LayerTabs.css';
+
+export default function LayerTabs({ layers, selected, onSelect, onAdd }) {
+  if (!layers || layers.length === 0) return null;
+  return (
+    <div className="layer-tabs">
+      {layers.map(layer => (
+        <button
+          key={layer.key}
+          className={layer.key === selected ? 'tab active' : 'tab'}
+          onClick={() => onSelect(layer.key)}
+        >
+          {layer.key}
+        </button>
+      ))}
+      {onAdd && (
+        <button className="tab add" onClick={onAdd}>+</button>
+      )}
+    </div>
+  );
+}

--- a/client/src/SourcesAgent.js
+++ b/client/src/SourcesAgent.js
@@ -1,0 +1,10 @@
+export function groupSourcesByLayer(data) {
+  const result = {};
+  if (!data.Sources) return result;
+  Object.entries(data.Sources).forEach(([key, value]) => {
+    const layer = key.split('.')[0];
+    if (!result[layer]) result[layer] = [];
+    result[layer].push({ key, value });
+  });
+  return result;
+}

--- a/client/src/TargetsAgent.js
+++ b/client/src/TargetsAgent.js
@@ -1,0 +1,10 @@
+export function groupTargetsByLayer(data) {
+  const result = {};
+  if (!data.Targets) return result;
+  Object.entries(data.Targets).forEach(([key, value]) => {
+    const layer = key.split('.')[0];
+    if (!result[layer]) result[layer] = [];
+    result[layer].push({ key, value });
+  });
+  return result;
+}


### PR DESCRIPTION
## Summary
- add tabbed navigation to browse layers
- list targets and sources within the active layer
- maintain previous functions for adding/removing layers
- group targets and sources by layer

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686774a207d0832f96428dde197499da