### PR TITLE
Refactor UI into components and add editor hook

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,243 +1,39 @@
-import { useState, useEffect } from 'react';
-import {
-  AppBar,
-  Toolbar,
-  Typography,
-  Box,
-  Button,
-  IconButton,
-  Snackbar,
-  Container,
-  Tabs,
-  Tab,
-  TextField,
-  Paper,
-  List,
-  ListItem,
-  ListItemText,
-} from '@mui/material';
-import Brightness7Icon from '@mui/icons-material/Brightness7';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import { openFile, exportFile } from './FileAgent.js';
-import { parseIni, stringifyIni } from './ParserAgent.js';
-import { listLayers, updateLayer, addLayer, removeLayer } from './LayersAgent.js';
-import { loadState, saveState, clearState } from './StorageAgent.js';
-import { groupTargetsByLayer } from './TargetsAgent.js';
-import { groupSourcesByLayer } from './SourcesAgent.js';
-
-function LayerTabs({ layers, selected, onSelect, onAdd }) {
-  if (!layers || layers.length === 0) return null;
-  return (
-    <Tabs
-      orientation="vertical"
-      value={layers.findIndex(l => l.key === selected)}
-      onChange={(e, idx) => onSelect(layers[idx].key)}
-      variant="scrollable"
-      sx={{ borderRight: 1, borderColor: 'divider', minWidth: 120, '& .MuiTab-root': { alignItems: 'flex-start' }, '& .MuiTabs-indicator': { width: 4 } }}
-    >
-      {layers.map(layer => (
-        <Tab key={layer.key} label={layer.key} sx={{ transition: 'background-color 0.3s', '&.Mui-selected': { bgcolor: 'action.selected' } }} />
-      ))}
-      <Tab label="+" onClick={onAdd} sx={{ fontWeight: 'bold' }} />
-    </Tabs>
-  );
-}
-
-function LayerPanel({ layer, targets, sources, onPathChange, onRemove }) {
-  if (!layer) return null;
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <Typography variant="h6" component="div">
-            Layer {layer.key}
-          </Typography>
-          <TextField
-            fullWidth
-            size="small"
-            value={layer.value}
-            onChange={e => onPathChange(layer.key, e.target.value)}
-            label="Path"
-          />
-          {onRemove && (
-            <Button color="error" onClick={() => onRemove(layer.key)}>
-              Delete
-            </Button>
-          )}
-        </Box>
-      </Paper>
-      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
-        <Typography variant="subtitle1" sx={{ mb: 1 }}>
-          Targets
-        </Typography>
-        <List dense disablePadding>
-          {targets.map(t => (
-            <ListItem key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-              <ListItemText
-                primary={<span className="mono">{t.key} = {t.value}</span>}
-              />
-            </ListItem>
-          ))}
-        </List>
-      </Paper>
-      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
-        <Typography variant="subtitle1" sx={{ mb: 1 }}>
-          Sources
-        </Typography>
-        <List dense disablePadding>
-          {sources.map(s => (
-            <ListItem key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-              <ListItemText
-                primary={<span className="mono">{s.key} = {s.value}</span>}
-              />
-            </ListItem>
-          ))}
-        </List>
-      </Paper>
-    </Box>
-  );
-}
+import { Box, Container, Snackbar, Typography } from '@mui/material';
+import LayerTabs from './components/Editor/LayerTabs.jsx';
+import LayerPanel from './components/Editor/LayerPanel.jsx';
+import Header from './components/Layout/Header.jsx';
+import useIniEditor from './hooks/useIniEditor.js';
 
 export default function App({ mode, toggleMode }) {
-  const [iniData, setIniData] = useState(null);
-  const [layers, setLayers] = useState([]);
-  const [targets, setTargets] = useState({});
-  const [sources, setSources] = useState({});
-  const [selectedLayer, setSelectedLayer] = useState(null);
-  const [fileName, setFileName] = useState('mappingfile.ini');
-  const [newline, setNewline] = useState('\n');
-  const [status, setStatus] = useState('');
-
-  useEffect(() => {
-    const saved = loadState();
-    if (saved) {
-      try {
-        const parsed = parseIni(saved.text);
-        setIniData(parsed);
-        const layerList = listLayers(parsed);
-        setLayers(layerList);
-        setTargets(groupTargetsByLayer(parsed));
-        setSources(groupSourcesByLayer(parsed));
-        setSelectedLayer(layerList[0]?.key || null);
-        setFileName(saved.fileName || 'mappingfile.ini');
-        setNewline(saved.newline || '\n');
-        setStatus('Restored previous session');
-      } catch (err) {
-        console.error(err);
-        clearState();
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    if (iniData) {
-      const text = stringifyIni(iniData, newline);
-      saveState({ text, fileName, newline });
-    } else {
-      clearState();
-    }
-  }, [iniData, fileName, newline]);
-
-  const handleFileChange = async e => {
-    const file = e.target.files[0];
-    if (!file) return;
-    try {
-      const { text, newline } = await openFile(file);
-      const parsed = parseIni(text);
-      setIniData(parsed);
-      const layerList = listLayers(parsed);
-      setLayers(layerList);
-      setTargets(groupTargetsByLayer(parsed));
-      setSources(groupSourcesByLayer(parsed));
-      setSelectedLayer(layerList[0]?.key || null);
-      setFileName(file.name);
-      setNewline(newline);
-      setStatus(`Loaded ${file.name}`);
-    } catch (err) {
-      console.error(err);
-      setStatus('Failed to read file');
-    }
-  };
-
-  const download = () => {
-    if (!iniData) return;
-    const text = stringifyIni(iniData, newline);
-    exportFile(text, fileName);
-  };
-
-  const handlePathChange = (key, value) => {
-    const index = layers.findIndex(l => l.key === key);
-    if (index === -1) return;
-    const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
-    updateLayer(dataCopy, index, key, value);
-    setIniData(dataCopy);
-    setLayers(listLayers(dataCopy));
-  };
-
-  const handleAddLayer = () => {
-    const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
-    const newKey = addLayer(dataCopy);
-    setIniData(dataCopy);
-    const updated = listLayers(dataCopy);
-    setLayers(updated);
-    setTargets(groupTargetsByLayer(dataCopy));
-    setSources(groupSourcesByLayer(dataCopy));
-    setSelectedLayer(newKey);
-  };
-
-  const handleRemoveLayer = key => {
-    const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
-    removeLayer(dataCopy, key);
-    setIniData(dataCopy);
-    const updated = listLayers(dataCopy);
-    setLayers(updated);
-    setTargets(groupTargetsByLayer(dataCopy));
-    setSources(groupSourcesByLayer(dataCopy));
-    setSelectedLayer(updated[0]?.key || null);
-  };
-
-  const reset = () => {
-    setIniData(null);
-    setLayers([]);
-    setTargets({});
-    setSources({});
-    setSelectedLayer(null);
-    setFileName('mappingfile.ini');
-    setNewline('\n');
-    setStatus('');
-    clearState();
-  };
+  const {
+    iniData,
+    layers,
+    targets,
+    sources,
+    selectedLayer,
+    status,
+    loading,
+    setStatus,
+    setSelectedLayer,
+    handleFileChange,
+    download,
+    handlePathChange,
+    handleAddLayer,
+    handleRemoveLayer,
+    reset,
+  } = useIniEditor();
 
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <AppBar position="static" sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}>
-        <Toolbar sx={{ gap: 2, minHeight: 64 }}>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            Mappy INI Editor
-          </Typography>
-          <input
-            type="file"
-            accept=".ini"
-            onChange={handleFileChange}
-            style={{ display: 'none' }}
-            id="file-input"
-          />
-          <label htmlFor="file-input">
-            <Button variant="contained" component="span">
-              Open
-            </Button>
-          </label>
-          <Button variant="contained" onClick={download} disabled={!iniData}>
-            Download
-          </Button>
-          <Button color="inherit" onClick={reset}>
-            Reset
-          </Button>
-          <IconButton color="inherit" onClick={toggleMode}>
-            {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+      <Header
+        mode={mode}
+        toggleMode={toggleMode}
+        iniData={iniData}
+        onFileSelect={handleFileChange}
+        onDownload={download}
+        onReset={reset}
+        loading={loading}
+      />
       {iniData ? (
         <Container maxWidth="md" sx={{ flex: 1, display: 'flex', overflow: 'hidden', py: 3 }}>
           <LayerTabs

--- a/client/src/components/Common/ErrorBoundary.jsx
+++ b/client/src/components/Common/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import { Component } from 'react';
+import { Typography, Box } from '@mui/material';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('UI Error:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box sx={{ p: 4 }}>
+          <Typography color="error">Something went wrong.</Typography>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;
+

--- a/client/src/components/Common/FileUpload.jsx
+++ b/client/src/components/Common/FileUpload.jsx
@@ -1,0 +1,18 @@
+import { Button } from '@mui/material';
+import UploadIcon from '@mui/icons-material/Upload';
+
+const FileUpload = ({ onFileSelect, id = 'file-input' }) => (
+  <Button component="label" variant="contained" startIcon={<UploadIcon />}> 
+    Open INI File
+    <input
+      type="file"
+      accept=".ini"
+      hidden
+      id={id}
+      onChange={onFileSelect}
+    />
+  </Button>
+);
+
+export default FileUpload;
+

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,0 +1,56 @@
+import { Box, Paper, Typography, TextField, Button, List, ListItem, ListItemText } from '@mui/material';
+import { memo } from 'react';
+
+const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
+  if (!layer) return null;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Typography variant="h6" component="div">
+            Layer {layer.key}
+          </Typography>
+          <TextField
+            fullWidth
+            size="small"
+            value={layer.value}
+            onChange={e => onPathChange(layer.key, e.target.value)}
+            label="Path"
+          />
+          {onRemove && (
+            <Button color="error" onClick={() => onRemove(layer.key)}>
+              Delete
+            </Button>
+          )}
+        </Box>
+      </Paper>
+      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>
+          Targets
+        </Typography>
+        <List dense disablePadding>
+          {targets.map(t => (
+            <ListItem key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+              <ListItemText primary={<span className="mono">{t.key} = {t.value}</span>} />
+            </ListItem>
+          ))}
+        </List>
+      </Paper>
+      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>
+          Sources
+        </Typography>
+        <List dense disablePadding>
+          {sources.map(s => (
+            <ListItem key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+              <ListItemText primary={<span className="mono">{s.key} = {s.value}</span>} />
+            </ListItem>
+          ))}
+        </List>
+      </Paper>
+    </Box>
+  );
+};
+
+export default memo(LayerPanel);
+

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -1,0 +1,24 @@
+import { Tabs, Tab } from '@mui/material';
+import { memo } from 'react';
+
+const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
+  if (!layers || layers.length === 0) return null;
+  const selectedIndex = layers.findIndex(l => l.key === selected);
+  return (
+    <Tabs
+      orientation="vertical"
+      value={selectedIndex}
+      onChange={(e, idx) => onSelect(layers[idx].key)}
+      variant="scrollable"
+      sx={{ borderRight: 1, borderColor: 'divider', minWidth: 120, '& .MuiTab-root': { alignItems: 'flex-start' }, '& .MuiTabs-indicator': { width: 4 } }}
+    >
+      {layers.map(layer => (
+        <Tab key={layer.key} label={layer.key} sx={{ transition: 'background-color 0.3s', '&.Mui-selected': { bgcolor: 'action.selected' } }} />
+      ))}
+      <Tab label="+" onClick={onAdd} sx={{ fontWeight: 'bold' }} />
+    </Tabs>
+  );
+};
+
+export default memo(LayerTabs);
+

--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -1,0 +1,27 @@
+import { AppBar, Toolbar, Typography, Button, IconButton } from '@mui/material';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import FileUpload from '../Common/FileUpload.jsx';
+
+const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, loading }) => (
+  <AppBar position="static" sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}>
+    <Toolbar sx={{ gap: 2, minHeight: 64 }}>
+      <Typography variant="h6" sx={{ flexGrow: 1 }}>
+        Mappy INI Editor
+      </Typography>
+      <FileUpload onFileSelect={onFileSelect} />
+      <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>
+        Download
+      </Button>
+      <Button color="inherit" onClick={onReset} disabled={loading}>
+        Reset
+      </Button>
+      <IconButton color="inherit" onClick={toggleMode} aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
+        {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+      </IconButton>
+    </Toolbar>
+  </AppBar>
+);
+
+export default Header;
+

--- a/client/src/hooks/useIniEditor.js
+++ b/client/src/hooks/useIniEditor.js
@@ -1,0 +1,143 @@
+import { useState, useEffect, useCallback } from 'react';
+import { openFile, exportFile } from '../FileAgent.js';
+import { parseIni, stringifyIni } from '../ParserAgent.js';
+import { listLayers, updateLayer, addLayer, removeLayer } from '../LayersAgent.js';
+import { loadState, saveState, clearState } from '../StorageAgent.js';
+import { groupTargetsByLayer } from '../TargetsAgent.js';
+import { groupSourcesByLayer } from '../SourcesAgent.js';
+
+export default function useIniEditor() {
+  const [iniData, setIniData] = useState(null);
+  const [layers, setLayers] = useState([]);
+  const [targets, setTargets] = useState({});
+  const [sources, setSources] = useState({});
+  const [selectedLayer, setSelectedLayer] = useState(null);
+  const [fileName, setFileName] = useState('mappingfile.ini');
+  const [newline, setNewline] = useState('\n');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const saved = loadState();
+    if (saved) {
+      try {
+        const parsed = parseIni(saved.text);
+        setIniData(parsed);
+        const layerList = listLayers(parsed);
+        setLayers(layerList);
+        setTargets(groupTargetsByLayer(parsed));
+        setSources(groupSourcesByLayer(parsed));
+        setSelectedLayer(layerList[0]?.key || null);
+        setFileName(saved.fileName || 'mappingfile.ini');
+        setNewline(saved.newline || '\n');
+        setStatus('Restored previous session');
+      } catch (err) {
+        console.error(err);
+        clearState();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (iniData) {
+      const text = stringifyIni(iniData, newline);
+      saveState({ text, fileName, newline });
+    } else {
+      clearState();
+    }
+  }, [iniData, fileName, newline]);
+
+  const handleFileChange = useCallback(async e => {
+    const file = e.target.files[0];
+    if (!file) return;
+    setLoading(true);
+    try {
+      const { text, newline } = await openFile(file);
+      const parsed = parseIni(text);
+      setIniData(parsed);
+      const layerList = listLayers(parsed);
+      setLayers(layerList);
+      setTargets(groupTargetsByLayer(parsed));
+      setSources(groupSourcesByLayer(parsed));
+      setSelectedLayer(layerList[0]?.key || null);
+      setFileName(file.name);
+      setNewline(newline);
+      setStatus(`Loaded ${file.name}`);
+    } catch (err) {
+      console.error(err);
+      setStatus('Failed to read file');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const download = useCallback(() => {
+    if (!iniData) return;
+    const text = stringifyIni(iniData, newline);
+    exportFile(text, fileName);
+  }, [iniData, newline, fileName]);
+
+  const handlePathChange = useCallback((key, value) => {
+    const index = layers.findIndex(l => l.key === key);
+    if (index === -1) return;
+    const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
+    updateLayer(dataCopy, index, key, value);
+    setIniData(dataCopy);
+    setLayers(listLayers(dataCopy));
+  }, [iniData, layers]);
+
+  const handleAddLayer = useCallback(() => {
+    const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
+    const newKey = addLayer(dataCopy);
+    setIniData(dataCopy);
+    const updated = listLayers(dataCopy);
+    setLayers(updated);
+    setTargets(groupTargetsByLayer(dataCopy));
+    setSources(groupSourcesByLayer(dataCopy));
+    setSelectedLayer(newKey);
+  }, [iniData]);
+
+  const handleRemoveLayer = useCallback(key => {
+    const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
+    removeLayer(dataCopy, key);
+    setIniData(dataCopy);
+    const updated = listLayers(dataCopy);
+    setLayers(updated);
+    setTargets(groupTargetsByLayer(dataCopy));
+    setSources(groupSourcesByLayer(dataCopy));
+    setSelectedLayer(updated[0]?.key || null);
+  }, [iniData]);
+
+  const reset = useCallback(() => {
+    setIniData(null);
+    setLayers([]);
+    setTargets({});
+    setSources({});
+    setSelectedLayer(null);
+    setFileName('mappingfile.ini');
+    setNewline('\n');
+    setStatus('');
+    clearState();
+  }, []);
+
+  return {
+    iniData,
+    layers,
+    targets,
+    sources,
+    selectedLayer,
+    fileName,
+    newline,
+    status,
+    loading,
+    setStatus,
+    setSelectedLayer,
+    handleFileChange,
+    download,
+    handlePathChange,
+    handleAddLayer,
+    handleRemoveLayer,
+    reset,
+  };
+}
+

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,8 +2,9 @@ import { StrictMode, useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
-import './index.css'
 import App from './App.jsx'
+import ErrorBoundary from './components/Common/ErrorBoundary.jsx'
+import './index.css'
 
 function Root() {
   const [mode, setMode] = useState('light')
@@ -20,7 +21,9 @@ function Root() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <App mode={mode} toggleMode={toggleMode} />
+      <ErrorBoundary>
+        <App mode={mode} toggleMode={toggleMode} />
+      </ErrorBoundary>
     </ThemeProvider>
   )
 }


### PR DESCRIPTION
## Summary
- split large editor logic into reusable components
- add `useIniEditor` hook for state management and memoized handlers
- provide `FileUpload`, `Header`, `LayerTabs`, and `LayerPanel` components
- include a simple `ErrorBoundary` wrapper
- update `App` and `main` to use the new pieces

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686784d59020832f9559f019cd708e91