### PR TITLE
Clarify layer paths and remove validation rule

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,8 @@
-# Agents for Mappy INI Editor
+# Agents for Mappy
 
 This document outlines the core "agents" (logical modules) in the Mappy web application. Each agent encapsulates a specific responsibility in the flow of loading, editing, validating, and exporting VSM mapping files. The goal is to keep each area of functionality cleanly separated, making the codebase easier to maintain and extend.
+
+Mappy is built to edit and manipulate VSM mapping files. These files describe paths to various external systems that VSM integrates with. Paths may include Nevion or VideoIPath segments but can reference any system name.
 
 ---
 
@@ -63,7 +65,7 @@ Each INI section gets its own agent to model its rows and enforce section-specif
 ### 4.1 LayersAgent
 
 * Manages entries in the `[Layers]` section.
-* Enforces: key = `NN`, value = `/Nevion/VideoIPath/.../Matrix`.
+* Manages keys formatted as `NN`. Values are paths describing the external system (they are not strictly validated).
 
 ### 4.2 TargetsAgent
 
@@ -137,24 +139,18 @@ This file has exactly three top-level sections, each with its own key-value patt
 A) [Layers]
 Key: two decimal digits, zero-padded (00 through 41)
 
-Value: a Unix-style path string, always starting with
+Value: a Unix-style path string describing the destination system.
+The path typically ends with `/Matrix`.
 
-swift
-Copy
-Edit
-/Nevion/VideoIPath/Version1/
-ending in either
+Example formats include:
 
 …/Connection/l<nn>/Matrix
 
 …/Device/<DeviceName>/Audio Levels/level_<nn>/Matrix
 
 Example:
-
-swift
-Copy
-Edit
 03 = /Nevion/VideoIPath/Version1/Connection/l77/Matrix
+
 B) [Targets]
 Key: <LL>.<CCCC>
 
@@ -165,11 +161,8 @@ CCCC = channel index, four decimal digits, zero-padded (0000–XXXX)
 Value: eight hexadecimal digits, zero-padded (00000000–FFFFFFFF), uppercase or lowercase
 
 Example:
-
-ini
-Copy
-Edit
 03.0005 = 00A1B2C3
+
 C) [Sources]
 Key: <LL>.<SSSS>
 
@@ -180,11 +173,8 @@ SSSS = source index, four digits (0000–9999)
 Value: eight-digit hex ID, same format as in [Targets]
 
 Example:
-
-ini
-Copy
-Edit
 03.0010 = 0000ABCD
+
 3. Validation rules
 Section names must be exactly Layers, Targets or Sources (case-sensitive).
 
@@ -196,7 +186,6 @@ Targets/Sources: ^[0-9]{2}\.[0-9]{4}$
 
 Values for hex IDs: ^[0-9A-Fa-f]{8}$
 
-Values for layer paths: must start with /Nevion/VideoIPath/Version1/ and end in /Matrix.
 
 4. Editor features to support
 Section picker (Layers, Targets, Sources)

--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,7 @@
 
-# Mappy INI Editor
+# Mappy
 
-This web app lets you edit NEVION iPath `.ini` mapping files directly in your browser. Open the page, upload an `.ini` file and download the edited version when you're done.
+This web app lets you edit VSM mapping files directly in your browser. Upload a mapping file and download the edited version when you're done.
 
 ## Development
 

--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
-    <title>Mappy INI Editor</title>
+    <title>Mappy</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,7 +2,7 @@ import { Box, Container, Snackbar, Typography } from '@mui/material';
 import LayerTabs from './components/Editor/LayerTabs.jsx';
 import LayerPanel from './components/Editor/LayerPanel.jsx';
 import Header from './components/Layout/Header.jsx';
-import useIniEditor from './hooks/useIniEditor.js';
+import useMappingEditor from './hooks/useMappingEditor.js';
 
 export default function App({ mode, toggleMode }) {
   const {
@@ -21,7 +21,7 @@ export default function App({ mode, toggleMode }) {
     handleAddLayer,
     handleRemoveLayer,
     reset,
-  } = useIniEditor();
+  } = useMappingEditor();
 
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
@@ -55,7 +55,7 @@ export default function App({ mode, toggleMode }) {
       ) : (
         <Box sx={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
           <Typography variant="h5" color="text.secondary" sx={{ textAlign: 'center' }}>
-            Upload an INI file to get started
+            Upload a mapping file to get started
           </Typography>
         </Box>
       )}

--- a/client/src/components/Common/FileUpload.jsx
+++ b/client/src/components/Common/FileUpload.jsx
@@ -2,8 +2,8 @@ import { Button } from '@mui/material';
 import UploadIcon from '@mui/icons-material/Upload';
 
 const FileUpload = ({ onFileSelect, id = 'file-input' }) => (
-  <Button component="label" variant="contained" startIcon={<UploadIcon />}> 
-    Open INI File
+  <Button component="label" variant="contained" startIcon={<UploadIcon />}>
+    Open Mapping File
     <input
       type="file"
       accept=".ini"

--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -7,7 +7,7 @@ const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, 
   <AppBar position="static" sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}>
     <Toolbar sx={{ gap: 2, minHeight: 64 }}>
       <Typography variant="h6" sx={{ flexGrow: 1 }}>
-        Mappy INI Editor
+        Mappy
       </Typography>
       <FileUpload onFileSelect={onFileSelect} />
       <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>

--- a/client/src/hooks/useMappingEditor.js
+++ b/client/src/hooks/useMappingEditor.js
@@ -6,7 +6,7 @@ import { loadState, saveState, clearState } from '../StorageAgent.js';
 import { groupTargetsByLayer } from '../TargetsAgent.js';
 import { groupSourcesByLayer } from '../SourcesAgent.js';
 
-export default function useIniEditor() {
+export default function useMappingEditor() {
   const [iniData, setIniData] = useState(null);
   const [layers, setLayers] = useState([]);
   const [targets, setTargets] = useState({});


### PR DESCRIPTION
## Summary
- clarify that layer paths are not strictly validated
- drop obsolete rule requiring `/Matrix` suffix

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68678db214e0832f9e6372eee7fc7119