### PR TITLE
Improve layer switching responsiveness

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,8 @@
         "@mui/material": "^7.2.0",
         "ini": "^5.0.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-window": "^1.8.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -2806,6 +2807,12 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3118,6 +3125,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/resolve": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "@mui/material": "^7.2.0",
     "ini": "^5.0.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-window": "^1.8.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,4 +1,5 @@
-import { Box, Paper, Typography, TextField, Button, List, ListItem, ListItemText } from '@mui/material';
+import { Box, Paper, Typography, TextField, Button, ListItem, ListItemText } from '@mui/material';
+import { FixedSizeList } from 'react-window';
 import { memo } from 'react';
 
 const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
@@ -28,25 +29,41 @@ const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
         <Typography variant="subtitle1" sx={{ mb: 1 }}>
           Targets
         </Typography>
-        <List dense disablePadding>
-          {targets.map(t => (
-            <ListItem key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-              <ListItemText primary={<span className="mono">{t.key} = {t.value}</span>} />
-            </ListItem>
-          ))}
-        </List>
+        <FixedSizeList
+          height={Math.min(300, targets.length * 36)}
+          itemCount={targets.length}
+          itemSize={36}
+          width="100%"
+        >
+          {({ index, style }) => {
+            const t = targets[index];
+            return (
+              <ListItem style={style} key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+                <ListItemText primary={<span className="mono">{t.key} = {t.value}</span>} />
+              </ListItem>
+            );
+          }}
+        </FixedSizeList>
       </Paper>
       <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
         <Typography variant="subtitle1" sx={{ mb: 1 }}>
           Sources
         </Typography>
-        <List dense disablePadding>
-          {sources.map(s => (
-            <ListItem key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-              <ListItemText primary={<span className="mono">{s.key} = {s.value}</span>} />
-            </ListItem>
-          ))}
-        </List>
+        <FixedSizeList
+          height={Math.min(300, sources.length * 36)}
+          itemCount={sources.length}
+          itemSize={36}
+          width="100%"
+        >
+          {({ index, style }) => {
+            const s = sources[index];
+            return (
+              <ListItem style={style} key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+                <ListItemText primary={<span className="mono">{s.key} = {s.value}</span>} />
+              </ListItem>
+            );
+          }}
+        </FixedSizeList>
       </Paper>
     </Box>
   );


### PR DESCRIPTION
## Summary
- virtualize target and source lists to cut render overhead
- include `react-window` dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867920b9104832f8ef0d5688b56240b