### PR TITLE
Fix layer sorting and improve layer list

### DIFF
--- a/client/src/LayersAgent.js
+++ b/client/src/LayersAgent.js
@@ -1,5 +1,7 @@
 export function listLayers(data) {
-  return Object.entries(data.Layers || {}).map(([key, value]) => ({ key, value }));
+  return Object.entries(data.Layers || {})
+    .sort((a, b) => parseInt(a[0], 10) - parseInt(b[0], 10))
+    .map(([key, value]) => ({ key, value }));
 }
 
 export function updateLayer(data, index, newKey, newValue) {

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -1,39 +1,45 @@
-import { Tabs, Tab } from '@mui/material';
+import { Box, ListItemButton, ListItemText } from '@mui/material';
+import { FixedSizeList } from 'react-window';
 import { memo } from 'react';
+
+const ITEM_HEIGHT = 36;
 
 const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
   if (!layers || layers.length === 0) return null;
-  const selectedIndex = layers.findIndex(l => l.key === selected);
-  const handleChange = (e, idx) => {
-    if (idx < layers.length) {
-      onSelect(layers[idx].key);
-    }
-  };
+
+  const height = Math.min(400, (layers.length + 1) * ITEM_HEIGHT);
+
   return (
-    <Tabs
-      orientation="vertical"
-      value={selectedIndex}
-      onChange={handleChange}
-      variant="scrollable"
-      sx={{
-        borderRight: 1,
-        borderColor: 'divider',
-        minWidth: 120,
-        '& .MuiTab-root': { alignItems: 'flex-start' },
-        '& .MuiTabs-indicator': { width: 4, transitionDuration: '150ms' },
-      }}
-    >
-      {layers.map(layer => (
-        <Tab
-          key={layer.key}
-          label={layer.key}
-          sx={{ transition: 'background-color 0.15s', '&.Mui-selected': { bgcolor: 'action.selected' } }}
-        />
-      ))}
-      <Tab label="+" onClick={onAdd} sx={{ fontWeight: 'bold' }} />
-    </Tabs>
+    <Box sx={{ borderRight: 1, borderColor: 'divider', minWidth: 120 }}>
+      <FixedSizeList
+        height={height}
+        itemCount={layers.length + 1}
+        itemSize={ITEM_HEIGHT}
+        width={120}
+      >
+        {({ index, style }) => {
+          if (index === layers.length) {
+            return (
+              <ListItemButton style={style} onClick={onAdd} sx={{ justifyContent: 'center' }}>
+                <ListItemText primary="+" sx={{ textAlign: 'center', fontWeight: 'bold' }} />
+              </ListItemButton>
+            );
+          }
+          const layer = layers[index];
+          return (
+            <ListItemButton
+              style={style}
+              selected={layer.key === selected}
+              onClick={() => onSelect(layer.key)}
+              sx={{ '&.Mui-selected': { bgcolor: 'action.selected' } }}
+            >
+              <ListItemText primary={layer.key} sx={{ fontFamily: 'monospace' }} />
+            </ListItemButton>
+          );
+        }}
+      </FixedSizeList>
+    </Box>
   );
 };
 
 export default memo(LayerTabs);
-


### PR DESCRIPTION
## Summary
- sort layer keys numerically when reading Layers
- virtualize layer list to better handle many layers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68679739edd0832f9d96f78a4d27b327