### PR TITLE
Improve scrollbars and list layout

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "ini": "^5.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-virtualized-auto-sizer": "^1.0.7",
         "react-window": "^1.8.8"
       },
       "devDependencies": {
@@ -3125,6 +3126,19 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz",
+      "integrity": "sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
       }
     },
     "node_modules/react-window": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "ini": "^5.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.8"
   },
   "devDependencies": {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -42,7 +42,7 @@ export default function App({ mode, toggleMode }) {
             onSelect={setSelectedLayer}
             onAdd={handleAddLayer}
           />
-          <Box sx={{ flex: 1, overflow: 'auto', pl: 3 }}>
+          <Box sx={{ flex: 1, overflow: 'hidden', pl: 3 }}>
             <LayerPanel
               layer={layers.find(l => l.key === selectedLayer)}
               targets={targets[selectedLayer] || []}

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,11 +1,12 @@
 import { Box, Paper, Typography, TextField, Button, ListItem } from '@mui/material';
 import { FixedSizeList } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
 import { memo } from 'react';
 
 const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
   if (!layer) return null;
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
       <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
           <Typography variant="h6" component="div">
@@ -25,8 +26,8 @@ const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
           )}
         </Box>
       </Paper>
-      <Box sx={{ display: 'flex', gap: 2 }}>
-        <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1 }}>
+      <Box sx={{ flex: 1, display: 'flex', gap: 2, overflow: 'hidden' }}>
+        <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
           <Typography variant="subtitle1" sx={{ mb: 1 }}>
             Targets
           </Typography>
@@ -35,36 +36,42 @@ const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
             <Box sx={{ width: '40%' }}>Value</Box>
             <Box sx={{ width: '20%', textAlign: 'right' }}>Offset</Box>
           </Box>
-          <FixedSizeList
-            height={Math.min(300, targets.length * 36)}
-            itemCount={targets.length}
-            itemSize={36}
-            width="100%"
-          >
-            {({ index, style }) => {
-              const t = targets[index];
-              return (
-                <ListItem style={style} key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-                  <Box sx={{ display: 'flex', width: '100%' }}>
-                    <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{t.key}</Box>
-                    <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{t.value}</Box>
-                    <Box
-                      sx={{
-                        width: '20%',
-                        textAlign: 'right',
-                        fontFamily: 'monospace',
-                        color: t.offset === 0 ? 'success.main' : 'error.main',
-                      }}
-                    >
-                      {t.offset}
-                    </Box>
-                  </Box>
-                </ListItem>
-              );
-            }}
-          </FixedSizeList>
+          <Box sx={{ flex: 1, minHeight: 0 }}>
+            <AutoSizer disableWidth>
+              {({ height }) => (
+                <FixedSizeList
+                  height={height}
+                  itemCount={targets.length}
+                  itemSize={36}
+                  width="100%"
+                >
+                  {({ index, style }) => {
+                    const t = targets[index];
+                    return (
+                      <ListItem style={style} key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+                        <Box sx={{ display: 'flex', width: '100%' }}>
+                          <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{t.key}</Box>
+                          <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{t.value}</Box>
+                          <Box
+                            sx={{
+                              width: '20%',
+                              textAlign: 'right',
+                              fontFamily: 'monospace',
+                              color: t.offset === 0 ? 'success.main' : 'error.main',
+                            }}
+                          >
+                            {t.offset}
+                          </Box>
+                        </Box>
+                      </ListItem>
+                    );
+                  }}
+                </FixedSizeList>
+              )}
+            </AutoSizer>
+          </Box>
         </Paper>
-        <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1 }}>
+        <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0 }}>
           <Typography variant="subtitle1" sx={{ mb: 1 }}>
             Sources
           </Typography>
@@ -73,34 +80,40 @@ const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
             <Box sx={{ width: '40%' }}>Value</Box>
             <Box sx={{ width: '20%', textAlign: 'right' }}>Offset</Box>
           </Box>
-          <FixedSizeList
-            height={Math.min(300, sources.length * 36)}
-            itemCount={sources.length}
-            itemSize={36}
-            width="100%"
-          >
-            {({ index, style }) => {
-              const s = sources[index];
-              return (
-                <ListItem style={style} key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-                  <Box sx={{ display: 'flex', width: '100%' }}>
-                    <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{s.key}</Box>
-                    <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{s.value}</Box>
-                    <Box
-                      sx={{
-                        width: '20%',
-                        textAlign: 'right',
-                        fontFamily: 'monospace',
-                        color: s.offset === 0 ? 'success.main' : 'error.main',
-                      }}
-                    >
-                      {s.offset}
-                    </Box>
-                  </Box>
-                </ListItem>
-              );
-            }}
-          </FixedSizeList>
+          <Box sx={{ flex: 1, minHeight: 0 }}>
+            <AutoSizer disableWidth>
+              {({ height }) => (
+                <FixedSizeList
+                  height={height}
+                  itemCount={sources.length}
+                  itemSize={36}
+                  width="100%"
+                >
+                  {({ index, style }) => {
+                    const s = sources[index];
+                    return (
+                      <ListItem style={style} key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+                        <Box sx={{ display: 'flex', width: '100%' }}>
+                          <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{s.key}</Box>
+                          <Box sx={{ width: '40%', fontFamily: 'monospace' }}>{s.value}</Box>
+                          <Box
+                            sx={{
+                              width: '20%',
+                              textAlign: 'right',
+                              fontFamily: 'monospace',
+                              color: s.offset === 0 ? 'success.main' : 'error.main',
+                            }}
+                          >
+                            {s.offset}
+                          </Box>
+                        </Box>
+                      </ListItem>
+                    );
+                  }}
+                </FixedSizeList>
+              )}
+            </AutoSizer>
+          </Box>
         </Paper>
       </Box>
     </Box>

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -1,5 +1,6 @@
 import { Box, ListItemButton, ListItemText } from '@mui/material';
 import { FixedSizeList } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
 import { memo } from 'react';
 
 const ITEM_HEIGHT = 36;
@@ -7,37 +8,39 @@ const ITEM_HEIGHT = 36;
 const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
   if (!layers || layers.length === 0) return null;
 
-  const height = Math.min(400, (layers.length + 1) * ITEM_HEIGHT);
-
   return (
-    <Box sx={{ borderRight: 1, borderColor: 'divider', minWidth: 120 }}>
-      <FixedSizeList
-        height={height}
-        itemCount={layers.length + 1}
-        itemSize={ITEM_HEIGHT}
-        width={120}
-      >
-        {({ index, style }) => {
-          if (index === layers.length) {
-            return (
-              <ListItemButton style={style} onClick={onAdd} sx={{ justifyContent: 'center' }}>
-                <ListItemText primary="+" sx={{ textAlign: 'center', fontWeight: 'bold' }} />
-              </ListItemButton>
-            );
-          }
-          const layer = layers[index];
-          return (
-            <ListItemButton
-              style={style}
-              selected={layer.key === selected}
-              onClick={() => onSelect(layer.key)}
-              sx={{ '&.Mui-selected': { bgcolor: 'action.selected' } }}
-            >
-              <ListItemText primary={layer.key} sx={{ fontFamily: 'monospace' }} />
-            </ListItemButton>
-          );
-        }}
-      </FixedSizeList>
+    <Box sx={{ borderRight: 1, borderColor: 'divider', minWidth: 120, height: '100%' }}>
+      <AutoSizer disableWidth>
+        {({ height }) => (
+          <FixedSizeList
+            height={height}
+            itemCount={layers.length + 1}
+            itemSize={ITEM_HEIGHT}
+            width={120}
+          >
+            {({ index, style }) => {
+              if (index === layers.length) {
+                return (
+                  <ListItemButton style={style} onClick={onAdd} sx={{ justifyContent: 'center' }}>
+                    <ListItemText primary="+" sx={{ textAlign: 'center', fontWeight: 'bold' }} />
+                  </ListItemButton>
+                );
+              }
+              const layer = layers[index];
+              return (
+                <ListItemButton
+                  style={style}
+                  selected={layer.key === selected}
+                  onClick={() => onSelect(layer.key)}
+                  sx={{ '&.Mui-selected': { bgcolor: 'action.selected' } }}
+                >
+                  <ListItemText primary={layer.key} sx={{ fontFamily: 'monospace' }} />
+                </ListItemButton>
+              );
+            }}
+          </FixedSizeList>
+        )}
+      </AutoSizer>
     </Box>
   );
 };

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -32,6 +32,26 @@ body {
   min-height: 100vh;
 }
 
+/* Consistent scrollbar styling */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #888 transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #555;
+  border-radius: 4px;
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
@@ -66,5 +86,9 @@ button:focus-visible {
   }
   button {
     background-color: #f9f9f9;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: #bbb;
   }
 }


### PR DESCRIPTION
## Summary
- style scrollbars to match MUI look
- allow `LayerTabs` and `LayerPanel` lists to use full available height
- use `react-virtualized-auto-sizer` for dynamic sizing

## Testing
- `npm --prefix client run lint`

------
https://chatgpt.com/codex/tasks/task_e_68679c39ed58832f80a70f072f303a43