### PR TITLE
Persist theme mode across refresh

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,4 +1,4 @@
-import { StrictMode, useMemo, useState } from 'react'
+import { StrictMode, useEffect, useMemo, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { ThemeProvider, createTheme } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
@@ -6,9 +6,16 @@ import App from './App.jsx'
 import ErrorBoundary from './components/Common/ErrorBoundary.jsx'
 import './index.css'
 
+const STORAGE_KEY = 'mappy_theme'
+
 function Root() {
-  const [mode, setMode] = useState('light')
-  const toggleMode = () => setMode(m => (m === 'light' ? 'dark' : 'light'))
+  const [mode, setMode] = useState(() => localStorage.getItem(STORAGE_KEY) || 'light')
+  const toggleMode = () =>
+    setMode(m => (m === 'light' ? 'dark' : 'light'))
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, mode)
+  }, [mode])
   const theme = useMemo(
     () =>
       createTheme({


### PR DESCRIPTION
## Summary
- store theme mode in localStorage
- restore saved theme when the app loads

## Testing
- `npm --prefix client run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679ee61138832f8053b3be59c1a041