### PR TITLE
UI tweak for layer list headers

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=JetBrains+Mono:wght@400;700&family=Baloo+2:wght@700&display=swap" rel="stylesheet">
     <title>Mappy</title>
   </head>
   <body>

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -1,4 +1,4 @@
-import { Box, ListItemButton, ListItemText, Paper } from '@mui/material';
+import { Box, ListItemButton, ListItemText, Paper, Typography } from '@mui/material';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { memo, useMemo } from 'react';
@@ -7,11 +7,11 @@ import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 const ITEM_HEIGHT = 36;
 
 const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
-  if (!layers || layers.length === 0) return null;
+  const hasLayers = layers && layers.length > 0;
 
   const labels = useMemo(
-    () => layers.map(l => formatLayerLabel(l.key, l.value)),
-    [layers]
+    () => (hasLayers ? layers.map(l => formatLayerLabel(l.key, l.value)) : []),
+    [layers, hasLayers]
   );
 
   const listWidth = useMemo(() => {
@@ -27,16 +27,25 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
     return Math.ceil(max + 32); // padding for ListItemButton
   }, [labels]);
 
+  if (!hasLayers) return null;
+
   return (
-    <Box sx={{ borderRight: 1, borderColor: 'divider', width: listWidth, height: '100%' }}>
-      <AutoSizer disableWidth>
-        {({ height }) => (
-          <FixedSizeList
-            height={height}
-            itemCount={layers.length + 1}
-            itemSize={ITEM_HEIGHT}
-            width={listWidth}
-          >
+    <Box sx={{ borderRight: 1, borderColor: 'divider', width: listWidth, height: '100%', display: 'flex', flexDirection: 'column', pt: 1 }}>
+      <Typography variant="h5" sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', textAlign: 'center', mb: 1 }}>
+        Mappy
+      </Typography>
+      <Typography variant="subtitle1" sx={{ textAlign: 'center', mb: 1 }}>
+        Layers
+      </Typography>
+      <Box sx={{ flex: 1, minHeight: 0 }}>
+        <AutoSizer disableWidth>
+          {({ height }) => (
+            <FixedSizeList
+              height={height}
+              itemCount={layers.length + 1}
+              itemSize={ITEM_HEIGHT}
+              width={listWidth}
+            >
           {({ index, style }) => {
             if (index === layers.length) {
               return (
@@ -72,6 +81,7 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
         )}
       </AutoSizer>
     </Box>
+  </Box>
   );
 };
 

--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -1,4 +1,4 @@
-import { AppBar, Toolbar, Typography, Button, IconButton } from '@mui/material';
+import { AppBar, Toolbar, Button, IconButton, Box } from '@mui/material';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import FileUpload from '../Common/FileUpload.jsx';
@@ -6,9 +6,7 @@ import FileUpload from '../Common/FileUpload.jsx';
 const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, loading }) => (
   <AppBar position="static" sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}>
     <Toolbar sx={{ gap: 2, minHeight: 64 }}>
-      <Typography variant="h6" sx={{ flexGrow: 1 }}>
-        Mappy
-      </Typography>
+      <Box sx={{ flexGrow: 1 }} />
       <FileUpload onFileSelect={onFileSelect} />
       <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>
         Download


### PR DESCRIPTION
## Summary
- move Mappy title from the header to the left column
- give the layer list its own "Layers" heading
- add Baloo 2 font for new title
- tweak layer tabs to avoid hook lint errors

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867ba02ca2c832fba9edde12c3e0c7f