### PR TITLE
Fix alignment of layer list

### DIFF
--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -45,8 +45,13 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
       }}
     >
       <Typography
-        variant="h5"
-        sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', textAlign: 'center' }}
+        variant="h3"
+        sx={{
+          fontFamily: '"Baloo 2", sans-serif',
+          fontWeight: 'bold',
+          textAlign: 'center',
+          lineHeight: 1,
+        }}
       >
         Mappy
       </Typography>


### PR DESCRIPTION
## Summary
- increase `Mappy` header size to line up with targets and sources

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867c72692f0832f94a25a14a57bf16c