### PR TITLE
Fix layer panel alignment

### DIFF
--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -41,7 +41,7 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
         display: 'flex',
         flexDirection: 'column',
         gap: 2,
-        pt: 1,
+        pt: 0,
       }}
     >
       <Typography
@@ -51,6 +51,7 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
           fontWeight: 'bold',
           textAlign: 'center',
           lineHeight: 1,
+          alignSelf: 'center',
         }}
       >
         Mappy


### PR DESCRIPTION
## Summary
- align top of Layers panel with Targets and Sources
- ensure "Mappy" heading centers correctly

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867c8ea2440832fae82d85c5e6c5aeb