### PR TITLE
Fix layer list alignment

### DIFF
--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -41,7 +41,7 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
         display: 'flex',
         flexDirection: 'column',
         gap: 2,
-        pt: 1,
+        pt: 3,
       }}
     >
       <Typography


### PR DESCRIPTION
## Summary
- increase top padding for layer list sidebar so it lines up with the targets and sources lists

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867c8ea2440832fae82d85c5e6c5aeb