### PR TITLE
Refactor layer list

### DIFF
--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -1,128 +1,66 @@
 import { Box, ListItemButton, ListItemText, Paper, Typography } from '@mui/material';
-import { FixedSizeList } from 'react-window';
-import AutoSizer from 'react-virtualized-auto-sizer';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo } from 'react';
 import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 
-const ITEM_HEIGHT = 36;
-
 const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
-  const hasLayers = layers && layers.length > 0;
-
-  const labels = useMemo(
-    () => (hasLayers ? layers.map(l => formatLayerLabel(l.key, l.value)) : []),
-    [layers, hasLayers]
-  );
-
-  const [listWidth, setListWidth] = useState(0);
-
-  useEffect(() => {
-    const span = document.createElement('span');
-    span.style.visibility = 'hidden';
-    span.style.position = 'absolute';
-    span.style.whiteSpace = 'nowrap';
-    span.style.font = '16px "JetBrains Mono", monospace';
-    document.body.appendChild(span);
-
-    const measure = () => {
-      span.textContent = '+';
-      let max = span.getBoundingClientRect().width;
-      for (const label of labels) {
-        span.textContent = label;
-        const w = span.getBoundingClientRect().width;
-        if (w > max) max = w;
-      }
-      setListWidth(Math.ceil(max + 32)); // padding for ListItemButton
-    };
-
-    measure();
-    if (document.fonts && document.fonts.ready) {
-      document.fonts.ready.then(measure);
-    }
-
-    return () => {
-      document.body.removeChild(span);
-    };
-  }, [labels]);
-
-  const containerWidth = listWidth + 32; // account for Paper padding
-  
-  if (!hasLayers) return null;
+  if (!layers || layers.length === 0) return null;
 
   return (
     <Box
       sx={{
         borderRight: 1,
         borderColor: 'divider',
-        width: containerWidth + 16,
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
         gap: 2,
         pt: 11,
         pr: 2,
+        width: 'max-content',
       }}
     >
       <Paper
-        sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        sx={{
+          p: 2,
+          borderRadius: 2,
+          boxShadow: 1,
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          overflowY: 'auto',
+        }}
       >
         <Typography variant="subtitle1" sx={{ mb: 1 }}>
           Layers
         </Typography>
-        <Box sx={{ flex: 1, minHeight: 0 }}>
-          <AutoSizer disableWidth>
-            {({ height }) => (
-              <FixedSizeList
-                height={height}
-                itemCount={layers.length + 1}
-                itemSize={ITEM_HEIGHT}
-                width={listWidth}
-              >
-                {({ index, style }) => {
-                  if (index === layers.length) {
-                    return (
-                      <Paper
-                        style={style}
-                        sx={{ height: ITEM_HEIGHT, display: 'flex' }}
-                        elevation={1}
-                      >
-                        <ListItemButton onClick={onAdd} sx={{ justifyContent: 'center' }}>
-                          <ListItemText
-                            primary="+"
-                            sx={{ textAlign: 'center', fontWeight: 'bold' }}
-                            primaryTypographyProps={{ noWrap: true, sx: { fontFamily: '"JetBrains Mono", monospace' } }}
-                          />
-                        </ListItemButton>
-                      </Paper>
-                    );
-                  }
-                  const layer = layers[index];
-                  const label = formatLayerLabel(layer.key, layer.value);
-                  return (
-                    <Paper
-                      style={style}
-                      elevation={layer.key === selected ? 2 : 1}
-                      sx={{ height: ITEM_HEIGHT, display: 'flex', '&:hover': { boxShadow: 3 } }}
-                    >
-                      <ListItemButton
-                        selected={layer.key === selected}
-                        onClick={() => onSelect(layer.key)}
-                        sx={{
-                          width: '100%',
-                          '&.Mui-selected': { bgcolor: 'action.selected' },
-                        }}
-                      >
-                        <ListItemText
-                          primary={label}
-                          primaryTypographyProps={{ noWrap: true, sx: { fontFamily: '"JetBrains Mono", monospace' } }}
-                        />
-                      </ListItemButton>
-                    </Paper>
-                  );
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          {layers.map(layer => (
+            <Paper
+              key={layer.key}
+              elevation={layer.key === selected ? 2 : 1}
+              sx={{ '&:hover': { boxShadow: 3 } }}
+            >
+              <ListItemButton
+                selected={layer.key === selected}
+                onClick={() => onSelect(layer.key)}
+                sx={{
+                  whiteSpace: 'nowrap',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  '&.Mui-selected': { bgcolor: 'action.selected' },
                 }}
-              </FixedSizeList>
-            )}
-          </AutoSizer>
+              >
+                <ListItemText primary={formatLayerLabel(layer.key, layer.value)} />
+              </ListItemButton>
+            </Paper>
+          ))}
+          <Paper elevation={1}>
+            <ListItemButton onClick={onAdd} sx={{ justifyContent: 'center' }}>
+              <ListItemText
+                primary="+"
+                sx={{ textAlign: 'center', fontWeight: 'bold', fontFamily: '"JetBrains Mono", monospace' }}
+              />
+            </ListItemButton>
+          </Paper>
         </Box>
       </Paper>
     </Box>


### PR DESCRIPTION
## Summary
- rewrite the layer list component
- use a simpler implementation that automatically sizes to its content
- remove virtualization logic that caused truncation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868232e24cc832f8c6defe53a8eb4ea