### PR TITLE
Remove separator in editor

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -42,7 +42,7 @@ export default function App({ mode, toggleMode }) {
             onSelect={setSelectedLayer}
             onAdd={handleAddLayer}
           />
-          <Box sx={{ flex: 1, overflow: 'auto', pl: 3 }}>
+          <Box sx={{ flex: 1, overflow: 'auto' }}>
             <LayerPanel
               layer={layers.find(l => l.key === selectedLayer)}
               targets={targets[selectedLayer] || []}

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -8,8 +8,6 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
   return (
     <Box
       sx={{
-        borderRight: 1,
-        borderColor: 'divider',
         height: '100%',
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
## Summary
- drop the right border from `LayerTabs`
- remove left padding on the layer panel so the path field spans the page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868269229b4832f8334e712e78f47c3