### PR TITLE
Fix layer path container width

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -35,7 +35,7 @@ export default function App({ mode, toggleMode }) {
         loading={loading}
       />
       {iniData ? (
-        <Container maxWidth={false} sx={{ flex: 1, display: 'flex', overflow: 'hidden', py: 3 }}>
+        <Container maxWidth={false} disableGutters sx={{ flex: 1, display: 'flex', overflow: 'hidden', py: 3 }}>
           <LayerTabs
             layers={layers}
             selected={selectedLayer}

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -7,8 +7,8 @@ const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
   if (!layer) return null;
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
-      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, width: '100%' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
           <Typography variant="h6" component="div" sx={{ whiteSpace: 'nowrap' }}>
             Layer {layer.key}
           </Typography>


### PR DESCRIPTION
## Summary
- expand LayerPanel path Paper to full width
- remove default MUI Container gutters so the editor uses the entire viewport

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68682b5bd988832f94b5dbfb8aeb50f7