### PR TITLE
Fix path row width

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,7 @@
 import { Box, Container, Snackbar, Typography } from '@mui/material';
 import LayerTabs from './components/Editor/LayerTabs.jsx';
 import LayerPanel from './components/Editor/LayerPanel.jsx';
+import LayerPathRow from './components/Editor/LayerPathRow.jsx';
 import Header from './components/Layout/Header.jsx';
 import useMappingEditor from './hooks/useMappingEditor.js';
 
@@ -35,20 +36,38 @@ export default function App({ mode, toggleMode }) {
         loading={loading}
       />
       {iniData ? (
-        <Container maxWidth={false} disableGutters sx={{ flex: 1, display: 'flex', overflow: 'hidden', py: 3 }}>
-          <LayerTabs
-            layers={layers}
-            selected={selectedLayer}
-            onSelect={setSelectedLayer}
-            onAdd={handleAddLayer}
-          />
-          <Box sx={{ flex: 1, overflow: 'auto' }}>
-            <LayerPanel
+        <Container
+          maxWidth={false}
+          disableGutters
+          sx={{
+            flex: 1,
+            display: 'grid',
+            overflow: 'hidden',
+            py: 3,
+            gridTemplateColumns: 'max-content 1fr',
+            gridTemplateRows: 'auto 1fr',
+            gridTemplateAreas: `"path path" "tabs panel"`,
+          }}
+        >
+          <Box sx={{ gridArea: 'path', mb: 2 }}>
+            <LayerPathRow
               layer={layers.find(l => l.key === selectedLayer)}
-              targets={targets[selectedLayer] || []}
-              sources={sources[selectedLayer] || []}
               onPathChange={handlePathChange}
               onRemove={handleRemoveLayer}
+            />
+          </Box>
+          <Box sx={{ gridArea: 'tabs', pr: 2 }}>
+            <LayerTabs
+              layers={layers}
+              selected={selectedLayer}
+              onSelect={setSelectedLayer}
+              onAdd={handleAddLayer}
+            />
+          </Box>
+          <Box sx={{ gridArea: 'panel', overflow: 'auto' }}>
+            <LayerPanel
+              targets={targets[selectedLayer] || []}
+              sources={sources[selectedLayer] || []}
             />
           </Box>
         </Container>

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,32 +1,11 @@
-import { Box, Paper, Typography, TextField, Button, ListItem } from '@mui/material';
+import { Box, Paper, Typography, ListItem } from '@mui/material';
 import { FixedSizeList } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { memo } from 'react';
 
-const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
-  if (!layer) return null;
+const LayerPanel = ({ targets, sources }) => {
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
-      <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, width: '100%' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
-          <Typography variant="h6" component="div" sx={{ whiteSpace: 'nowrap' }}>
-            Layer {layer.key}
-          </Typography>
-          <TextField
-            fullWidth
-            size="small"
-            value={layer.value}
-            onChange={e => onPathChange(layer.key, e.target.value)}
-            label="Path"
-          />
-          {onRemove && (
-            <Button color="error" onClick={() => onRemove(layer.key)}>
-              Delete
-            </Button>
-          )}
-        </Box>
-      </Paper>
-      <Box sx={{ display: 'flex', gap: 2, flex: 1 }}>
+    <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
         <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
           <Typography variant="subtitle1" sx={{ mb: 1 }}>
             Targets
@@ -115,7 +94,6 @@ const LayerPanel = ({ layer, targets, sources, onPathChange, onRemove }) => {
             </AutoSizer>
           </Box>
         </Paper>
-      </Box>
     </Box>
   );
 };

--- a/client/src/components/Editor/LayerPathRow.jsx
+++ b/client/src/components/Editor/LayerPathRow.jsx
@@ -1,0 +1,29 @@
+import { Paper, Box, Typography, TextField, Button } from '@mui/material';
+import { memo } from 'react';
+
+const LayerPathRow = ({ layer, onPathChange, onRemove }) => {
+  if (!layer) return null;
+  return (
+    <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, width: '100%' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '100%' }}>
+        <Typography variant="h6" component="div" sx={{ whiteSpace: 'nowrap' }}>
+          Layer {layer.key}
+        </Typography>
+        <TextField
+          fullWidth
+          size="small"
+          value={layer.value}
+          onChange={e => onPathChange(layer.key, e.target.value)}
+          label="Path"
+        />
+        {onRemove && (
+          <Button color="error" onClick={() => onRemove(layer.key)}>
+            Delete
+          </Button>
+        )}
+      </Box>
+    </Paper>
+  );
+};
+
+export default memo(LayerPathRow);

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -12,7 +12,6 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
         display: 'flex',
         flexDirection: 'column',
         gap: 2,
-        pt: 11,
         pr: 2,
         width: 'max-content',
       }}


### PR DESCRIPTION
## Summary
- make the layer path editor span the full width
- simplify `LayerPanel` and reuse new `LayerPathRow` component
- use CSS grid in `App` layout so the path editor is top row

## Testing
- `npm --prefix client run build`

------
https://chatgpt.com/codex/tasks/task_e_6868373a7c24832f9d0ae3187973bbfc