### PR TITLE
Refactor lists with reusable virtualized component

### DIFF
--- a/client/src/components/Common/VirtualizedList.jsx
+++ b/client/src/components/Common/VirtualizedList.jsx
@@ -1,0 +1,23 @@
+import { memo } from 'react';
+import { FixedSizeList } from 'react-window';
+import AutoSizer from 'react-virtualized-auto-sizer';
+
+const VirtualizedList = ({ items = [], itemHeight = 36, renderRow }) => {
+  if (typeof renderRow !== 'function') return null;
+  return (
+    <AutoSizer>
+      {({ height, width }) => (
+        <FixedSizeList
+          height={height}
+          width={width}
+          itemCount={items.length}
+          itemSize={itemHeight}
+        >
+          {({ index, style }) => renderRow(items[index], index, style)}
+        </FixedSizeList>
+      )}
+    </AutoSizer>
+  );
+};
+
+export default memo(VirtualizedList);

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,7 +1,6 @@
 import { Box, Paper, Typography, ListItem } from '@mui/material';
-import { FixedSizeList } from 'react-window';
-import AutoSizer from 'react-virtualized-auto-sizer';
 import { memo } from 'react';
+import VirtualizedList from '../Common/VirtualizedList.jsx';
 
 const LayerPanel = ({ targets, sources }) => {
   return (
@@ -16,38 +15,28 @@ const LayerPanel = ({ targets, sources }) => {
             <Box sx={{ width: '20%', textAlign: 'right' }}>Offset</Box>
           </Box>
           <Box sx={{ flex: 1, minHeight: 0 }}>
-            <AutoSizer>
-              {({ height, width }) => (
-                <FixedSizeList
-                  height={height}
-                  width={width}
-                  itemCount={targets.length}
-                  itemSize={36}
-                >
-                  {({ index, style }) => {
-                    const t = targets[index];
-                    return (
-                      <ListItem style={style} key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-                        <Box sx={{ display: 'flex', width: '100%' }}>
-                          <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{t.key}</Box>
-                          <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{t.value}</Box>
-                          <Box
-                            sx={{
-                              width: '20%',
-                              textAlign: 'right',
-                              fontFamily: '"JetBrains Mono", monospace',
-                              color: t.offset === 0 ? 'success.dark' : 'error.dark',
-                            }}
-                          >
-                            {t.offset}
-                          </Box>
-                        </Box>
-                      </ListItem>
-                    );
-                  }}
-                </FixedSizeList>
+            <VirtualizedList
+              items={targets}
+              itemHeight={36}
+              renderRow={(t, _i, style) => (
+                <ListItem style={style} key={t.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+                  <Box sx={{ display: 'flex', width: '100%' }}>
+                    <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{t.key}</Box>
+                    <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{t.value}</Box>
+                    <Box
+                      sx={{
+                        width: '20%',
+                        textAlign: 'right',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        color: t.offset === 0 ? 'success.dark' : 'error.dark',
+                      }}
+                    >
+                      {t.offset}
+                    </Box>
+                  </Box>
+                </ListItem>
               )}
-            </AutoSizer>
+            />
           </Box>
         </Paper>
         <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
@@ -60,38 +49,28 @@ const LayerPanel = ({ targets, sources }) => {
             <Box sx={{ width: '20%', textAlign: 'right' }}>Offset</Box>
           </Box>
           <Box sx={{ flex: 1, minHeight: 0 }}>
-            <AutoSizer>
-              {({ height, width }) => (
-                <FixedSizeList
-                  height={height}
-                  width={width}
-                  itemCount={sources.length}
-                  itemSize={36}
-                >
-                  {({ index, style }) => {
-                    const s = sources[index];
-                    return (
-                      <ListItem style={style} key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
-                        <Box sx={{ display: 'flex', width: '100%' }}>
-                          <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{s.key}</Box>
-                          <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{s.value}</Box>
-                          <Box
-                            sx={{
-                              width: '20%',
-                              textAlign: 'right',
-                              fontFamily: '"JetBrains Mono", monospace',
-                              color: s.offset === 0 ? 'success.dark' : 'error.dark',
-                            }}
-                          >
-                            {s.offset}
-                          </Box>
-                        </Box>
-                      </ListItem>
-                    );
-                  }}
-                </FixedSizeList>
+            <VirtualizedList
+              items={sources}
+              itemHeight={36}
+              renderRow={(s, _i, style) => (
+                <ListItem style={style} key={s.key} sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}>
+                  <Box sx={{ display: 'flex', width: '100%' }}>
+                    <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{s.key}</Box>
+                    <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{s.value}</Box>
+                    <Box
+                      sx={{
+                        width: '20%',
+                        textAlign: 'right',
+                        fontFamily: '"JetBrains Mono", monospace',
+                        color: s.offset === 0 ? 'success.dark' : 'error.dark',
+                      }}
+                    >
+                      {s.offset}
+                    </Box>
+                  </Box>
+                </ListItem>
               )}
-            </AutoSizer>
+            />
           </Box>
         </Paper>
     </Box>

--- a/client/src/components/Editor/LayerTabs.jsx
+++ b/client/src/components/Editor/LayerTabs.jsx
@@ -1,5 +1,6 @@
 import { Box, ListItemButton, ListItemText, Paper, Typography } from '@mui/material';
 import { memo } from 'react';
+import VirtualizedList from '../Common/VirtualizedList.jsx';
 import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 
 const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
@@ -30,25 +31,30 @@ const LayerTabs = ({ layers, selected, onSelect, onAdd }) => {
         <Typography variant="subtitle1" sx={{ mb: 1 }}>
           Layers
         </Typography>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-          {layers.map(layer => (
-            <Paper
-              key={layer.key}
-              elevation={layer.key === selected ? 2 : 1}
-              sx={{ '&:hover': { boxShadow: 3 } }}
-            >
-              <ListItemButton
-                selected={layer.key === selected}
-                onClick={() => onSelect(layer.key)}
-                sx={{ '&.Mui-selected': { bgcolor: 'action.selected' } }}
-              >
-                <ListItemText
-                  primary={formatLayerLabel(layer.key, layer.value)}
-                  primaryTypographyProps={{ noWrap: true, sx: { fontFamily: '"JetBrains Mono", monospace' } }}
-                />
-              </ListItemButton>
-            </Paper>
-          ))}
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flex: 1, minHeight: 0 }}>
+          <VirtualizedList
+            items={layers}
+            itemHeight={48}
+            renderRow={(layer, _i, style) => (
+              <Box style={style} key={layer.key}>
+                <Paper
+                  elevation={layer.key === selected ? 2 : 1}
+                  sx={{ '&:hover': { boxShadow: 3 } }}
+                >
+                  <ListItemButton
+                    selected={layer.key === selected}
+                    onClick={() => onSelect(layer.key)}
+                    sx={{ '&.Mui-selected': { bgcolor: 'action.selected' } }}
+                  >
+                    <ListItemText
+                      primary={formatLayerLabel(layer.key, layer.value)}
+                      primaryTypographyProps={{ noWrap: true, sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                    />
+                  </ListItemButton>
+                </Paper>
+              </Box>
+            )}
+          />
           <Paper elevation={1}>
             <ListItemButton onClick={onAdd} sx={{ justifyContent: 'center' }}>
               <ListItemText


### PR DESCRIPTION
## Summary
- create `VirtualizedList` shared component based on react-window
- update `LayerPanel` to use `VirtualizedList` for targets and sources
- update `LayerTabs` to display layers with the new virtualized list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868e3f0f460832fb724deb539e69186