### PR TITLE
Adjust layer list width

### DIFF
--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -8,6 +8,7 @@ export default function EntryList({
   header,
   footer,
   itemHeight = 36,
+  paperProps = {},
 }) {
   const defaultHeader = (
     <Box sx={{ display: 'flex', px: 1, fontWeight: 'bold', fontFamily: '"JetBrains Mono", monospace' }}>
@@ -42,7 +43,17 @@ export default function EntryList({
 
   return (
     <Paper
-      sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+      {...paperProps}
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        boxShadow: 1,
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        ...(paperProps.sx || {}),
+      }}
     >
       <Typography variant="subtitle1" sx={{ mb: 1 }}>
         {title}

--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -30,8 +30,22 @@ const LayerList = ({ layers = [], selected, onSelect, onAdd }) => {
     </Box>
   );
 
+  const maxLabelLength = layers.reduce(
+    (max, l) => Math.max(max, formatLayerLabel(l.key, l.value).length),
+    0,
+  );
+
+  const width = `calc(${maxLabelLength}ch + 2rem)`;
+
   return (
-    <EntryList title="Layers" items={layers} renderRow={renderRow} header={header} footer={footer} />
+    <EntryList
+      title="Layers"
+      items={layers}
+      renderRow={renderRow}
+      header={header}
+      footer={footer}
+      paperProps={{ sx: { flex: '0 0 auto', width } }}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary
- allow custom Paper props in `EntryList`
- size the layer list according to the longest label

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868ef08abc0832f9ad57698d5fd6468