### PR TITLE
Adjust layer list width

### DIFF
--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -8,6 +8,7 @@ export default function EntryList({
   header,
   footer,
   itemHeight = 36,
+  paperProps = {},
 }) {
   const defaultHeader = (
     <Box sx={{ display: 'flex', px: 1, fontWeight: 'bold', fontFamily: '"JetBrains Mono", monospace' }}>
@@ -42,7 +43,17 @@ export default function EntryList({
 
   return (
     <Paper
-      sx={{ p: 2, borderRadius: 2, boxShadow: 1, flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+      {...paperProps}
+      sx={{
+        p: 2,
+        borderRadius: 2,
+        boxShadow: 1,
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        ...(paperProps.sx || {}),
+      }}
     >
       <Typography variant="subtitle1" sx={{ mb: 1 }}>
         {title}

--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -1,5 +1,5 @@
 import { Box, ListItemButton, ListItemText } from '@mui/material';
-import { memo } from 'react';
+import { memo, useLayoutEffect, useRef, useState } from 'react';
 import EntryList from '../Common/EntryList.jsx';
 import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 
@@ -30,8 +30,46 @@ const LayerList = ({ layers = [], selected, onSelect, onAdd }) => {
     </Box>
   );
 
+  const longestLabel = layers.reduce((acc, l) => {
+    const label = formatLayerLabel(l.key, l.value);
+    return label.length > acc.length ? label : acc;
+  }, '');
+
+  const measureRef = useRef(null);
+  const [width, setWidth] = useState('auto');
+
+  useLayoutEffect(() => {
+    if (measureRef.current) {
+      setWidth(`${measureRef.current.offsetWidth}px`);
+    }
+  }, [longestLabel]);
+
   return (
-    <EntryList title="Layers" items={layers} renderRow={renderRow} header={header} footer={footer} />
+    <>
+      <ListItemButton
+        ref={measureRef}
+        sx={{
+          position: 'absolute',
+          visibility: 'hidden',
+          pointerEvents: 'none',
+          px: 2,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <ListItemText
+          primary={longestLabel}
+          primaryTypographyProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+        />
+      </ListItemButton>
+      <EntryList
+        title="Layers"
+        items={layers}
+        renderRow={renderRow}
+        header={header}
+        footer={footer}
+        paperProps={{ sx: { flex: '0 0 auto', width } }}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- allow custom Paper props in `EntryList`
- size the layer list according to the longest label using DOM measurement

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868ef08abc0832f9ad57698d5fd6468