### PR TITLE
Fix layer list resize when fonts load

### DIFF
--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -39,9 +39,18 @@ const LayerList = ({ layers = [], selected, onSelect, onAdd }) => {
   const [width, setWidth] = useState('auto');
 
   useLayoutEffect(() => {
-    if (measureRef.current) {
-      setWidth(`${measureRef.current.offsetWidth}px`);
-    }
+    const node = measureRef.current;
+    if (!node) return;
+
+    const updateWidth = () => {
+      setWidth(`${node.offsetWidth}px`);
+    };
+
+    updateWidth();
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(node);
+    return () => observer.disconnect();
   }, [longestLabel]);
 
   return (


### PR DESCRIPTION
## Summary
- keep the `LayerList` width in sync with font-loading

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6868f381f604832fb512d4c31ba38b06