### PR TITLE
Fix font loading width issue in LayerList

### DIFF
--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -39,9 +39,23 @@ const LayerList = ({ layers = [], selected, onSelect, onAdd }) => {
   const [width, setWidth] = useState('auto');
 
   useLayoutEffect(() => {
-    if (measureRef.current) {
-      setWidth(`${measureRef.current.offsetWidth}px`);
+    let cancelled = false;
+
+    const measure = () => {
+      if (!cancelled && measureRef.current) {
+        setWidth(`${measureRef.current.offsetWidth}px`);
+      }
+    };
+
+    measure();
+
+    if (document.fonts && typeof document.fonts.ready?.then === 'function') {
+      document.fonts.ready.then(measure);
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [longestLabel]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure LayerList width is measured again once fonts load so names don't get truncated

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868f381f604832fb512d4c31ba38b06