### PR TITLE
Unify list row effects

### DIFF
--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -1,4 +1,4 @@
-import { Box, ListItem, Paper, Typography } from '@mui/material';
+import { Box, ListItemButton, Paper, Typography } from '@mui/material';
 import VirtualizedList from './VirtualizedList.jsx';
 
 export default function EntryList({
@@ -19,14 +19,20 @@ export default function EntryList({
   );
 
   const defaultRow = (item, _i, style) => (
-    <ListItem
-      style={style}
-      key={item.key}
-      sx={{ mb: 0.5, borderRadius: 1, '&:hover': { boxShadow: 2 } }}
-    >
-      <Box sx={{ display: 'flex', width: '100%' }}>
-        <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{item.key}</Box>
-        <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{item.value}</Box>
+    <Box style={style} key={item.key}>
+      <ListItemButton
+        sx={{
+          height: '100%',
+          minHeight: 0,
+          py: 0,
+          mb: 0.5,
+          borderRadius: 1,
+          '&.Mui-selected': { bgcolor: 'action.selected' },
+        }}
+      >
+        <Box sx={{ display: 'flex', width: '100%' }}>
+          <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{item.key}</Box>
+          <Box sx={{ width: '40%', fontFamily: '"JetBrains Mono", monospace' }}>{item.value}</Box>
         <Box
           sx={{
             width: '20%',
@@ -37,8 +43,9 @@ export default function EntryList({
         >
           {item.offset}
         </Box>
-      </Box>
-    </ListItem>
+        </Box>
+      </ListItemButton>
+    </Box>
   );
 
   return (


### PR DESCRIPTION
## Summary
- use same ListItemButton layout as LayerList for EntryList rows

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686901654f2c832f95e880b664277ae9