### PR TITLE
Refactor layer management UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ export default function App({ mode, toggleMode }) {
     handleFileChange,
     download,
     handlePathChange,
+    handleAddLayer,
     handleRemoveLayer,
     reset,
   } = useMappingEditor();
@@ -50,7 +51,7 @@ export default function App({ mode, toggleMode }) {
             <LayerPathRow
               layer={layers.find(l => l.key === selectedLayer)}
               onPathChange={handlePathChange}
-              onRemove={handleRemoveLayer}
+              onAdd={handleAddLayer}
             />
           </Box>
           <Box sx={{ gridArea: 'lists', overflow: 'auto' }}>
@@ -60,6 +61,8 @@ export default function App({ mode, toggleMode }) {
               sources={sources[selectedLayer] || []}
               selectedLayer={selectedLayer}
               onSelectLayer={setSelectedLayer}
+              onDeleteLayer={handleRemoveLayer}
+              onError={setStatus}
             />
           </Box>
         </Container>

--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -1,14 +1,38 @@
-import { Box, ListItemButton, ListItemText } from '@mui/material';
+import {
+  Box,
+  ListItemButton,
+  ListItemText,
+  IconButton,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import DeleteIcon from '@mui/icons-material/Delete';
 import { memo, useLayoutEffect, useRef, useState } from 'react';
 import EntryList from '../Common/EntryList.jsx';
 import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 
-const LayerList = ({ layers = [], selected, onSelect }) => {
+const LayerList = ({ layers = [], selected, onSelect, onDelete, onError }) => {
   const header = null;
   const footer = null; // Remove the "+" button
 
+  const [menuAnchor, setMenuAnchor] = useState(null);
+  const [activeMenuLayer, setActiveMenuLayer] = useState(null);
+  const [confirmLayer, setConfirmLayer] = useState(null);
+
   const renderRow = (layer, _i, style) => (
-    <Box style={style} key={layer.key}>
+    <Box
+      style={style}
+      key={layer.key}
+      sx={{ position: 'relative', '&:hover .layer-menu-btn': { opacity: 1 } }}
+    >
       <ListItemButton
         selected={layer.key === selected}
         onClick={() => onSelect(layer.key)}
@@ -16,6 +40,7 @@ const LayerList = ({ layers = [], selected, onSelect }) => {
           height: '100%',
           minHeight: 0,
           py: 0,
+          pr: 4,
           mb: 0.5,
           borderRadius: 1,
           '&.Mui-selected': { bgcolor: 'action.selected' },
@@ -23,9 +48,34 @@ const LayerList = ({ layers = [], selected, onSelect }) => {
       >
         <ListItemText
           primary={formatLayerLabel(layer.key, layer.value)}
-          primaryTypographyProps={{ noWrap: true, sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+          primaryTypographyProps={{
+            noWrap: true,
+            sx: { fontFamily: '"JetBrains Mono", monospace' },
+          }}
         />
       </ListItemButton>
+      <IconButton
+        className="layer-menu-btn"
+        size="small"
+        onClick={e => {
+          e.stopPropagation();
+          setMenuAnchor(e.currentTarget);
+          setActiveMenuLayer(layer.key);
+        }}
+        sx={{
+          position: 'absolute',
+          right: 0,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          opacity: 0,
+          transition: 'opacity 0.1s',
+          color: 'action.disabled',
+          p: '4px',
+          '&:hover': { color: 'action.active' },
+        }}
+      >
+        <MoreVertIcon fontSize="small" />
+      </IconButton>
     </Box>
   );
 
@@ -73,6 +123,26 @@ const LayerList = ({ layers = [], selected, onSelect }) => {
     };
   }, [longestLabel]);
 
+  const handleMenuClose = () => {
+    setMenuAnchor(null);
+    setActiveMenuLayer(null);
+  };
+
+  const handleDeleteClick = () => {
+    if (layers.length <= 1) {
+      onError && onError('Cannot delete the last remaining layer');
+      handleMenuClose();
+      return;
+    }
+    setConfirmLayer(activeMenuLayer);
+    handleMenuClose();
+  };
+
+  const confirmDelete = () => {
+    if (onDelete) onDelete(confirmLayer);
+    setConfirmLayer(null);
+  };
+
   return (
     <>
       <Box
@@ -108,6 +178,33 @@ const LayerList = ({ layers = [], selected, onSelect }) => {
         footer={footer}
         paperProps={{ sx: { flex: '0 0 auto', width } }}
       />
+      <Menu
+        anchorEl={menuAnchor}
+        open={Boolean(menuAnchor)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={handleDeleteClick}>
+          <ListItemIcon>
+            <DeleteIcon fontSize="small" />
+          </ListItemIcon>
+          Delete Layer
+        </MenuItem>
+      </Menu>
+      <Dialog
+        open={Boolean(confirmLayer)}
+        onClose={() => setConfirmLayer(null)}
+      >
+        <DialogTitle>{`Delete Layer ${confirmLayer}?`}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmLayer(null)}>Cancel</Button>
+          <Button color="error" onClick={confirmDelete}>Delete</Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -8,12 +8,16 @@ const LayerPanel = ({
   sources,
   selectedLayer,
   onSelectLayer,
+  onDeleteLayer,
+  onError,
 }) => (
   <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
     <LayerList
       layers={layers}
       selected={selectedLayer}
       onSelect={onSelectLayer}
+      onDelete={onDeleteLayer}
+      onError={onError}
     />
     <EntryList title="Targets" items={targets} />
     <EntryList title="Sources" items={sources} />

--- a/client/src/components/Editor/LayerPathRow.jsx
+++ b/client/src/components/Editor/LayerPathRow.jsx
@@ -1,7 +1,8 @@
 import { Paper, Box, Typography, TextField, Button } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import { memo } from 'react';
 
-const LayerPathRow = ({ layer, onPathChange, onRemove }) => {
+const LayerPathRow = ({ layer, onPathChange, onAdd }) => {
   if (!layer) return null;
   return (
     <Paper sx={{ p: 2, borderRadius: 2, boxShadow: 1, width: '100%' }}>
@@ -16,9 +17,13 @@ const LayerPathRow = ({ layer, onPathChange, onRemove }) => {
           onChange={e => onPathChange(layer.key, e.target.value)}
           label="Path"
         />
-        {onRemove && (
-          <Button color="error" onClick={() => onRemove(layer.key)}>
-            Delete
+        {onAdd && (
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            onClick={onAdd}
+          >
+            Add Layer
           </Button>
         )}
       </Box>

--- a/client/src/hooks/useMappingEditor.js
+++ b/client/src/hooks/useMappingEditor.js
@@ -98,6 +98,7 @@ export default function useMappingEditor() {
   }, [iniData]);
 
   const handleRemoveLayer = useCallback(key => {
+    const idx = layers.findIndex(l => l.key === key);
     const dataCopy = { ...iniData, Layers: { ...iniData.Layers } };
     removeLayer(dataCopy, key);
     setIniData(dataCopy);
@@ -105,8 +106,10 @@ export default function useMappingEditor() {
     setLayers(updated);
     setTargets(groupTargetsByLayer(dataCopy));
     setSources(groupSourcesByLayer(dataCopy));
-    setSelectedLayer(updated[0]?.key || null);
-  }, [iniData]);
+    const nextKey =
+      idx > 0 ? updated[idx - 1]?.key : updated[0]?.key || null;
+    setSelectedLayer(nextKey);
+  }, [iniData, layers]);
 
   const reset = useCallback(() => {
     setIniData(null);


### PR DESCRIPTION
## Summary
- swap LayerPathRow's delete button for "Add Layer"
- introduce per-layer context menu for deletion
- handle layer deletion via confirmation dialog
- update selection logic when deleting layers
- wire up menu state management in LayerList

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68690ee6fcf0832fa3f2790be1bf54f3