### PR TITLE
Add modal editors for Targets and Sources

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,8 @@ export default function App({ mode, toggleMode }) {
     handlePathChange,
     handleAddLayer,
     handleRemoveLayer,
+    replaceTargetsForLayer,
+    replaceSourcesForLayer,
     reset,
   } = useMappingEditor();
 
@@ -63,6 +65,8 @@ export default function App({ mode, toggleMode }) {
               onSelectLayer={setSelectedLayer}
               onDeleteLayer={handleRemoveLayer}
               onError={setStatus}
+              onEditTargets={entries => replaceTargetsForLayer(selectedLayer, entries)}
+              onEditSources={entries => replaceSourcesForLayer(selectedLayer, entries)}
             />
           </Box>
         </Container>

--- a/client/src/SourcesAgent.js
+++ b/client/src/SourcesAgent.js
@@ -18,3 +18,13 @@ export function removeLayerSources(data, layer) {
     if (key.startsWith(`${layer}.`)) delete data.Sources[key];
   });
 }
+
+export function replaceLayerSources(data, layer, entries) {
+  if (!data.Sources) data.Sources = {};
+  Object.keys(data.Sources).forEach(key => {
+    if (key.startsWith(`${layer}.`)) delete data.Sources[key];
+  });
+  entries.forEach(({ key, value }) => {
+    data.Sources[key] = value;
+  });
+}

--- a/client/src/TargetsAgent.js
+++ b/client/src/TargetsAgent.js
@@ -18,3 +18,13 @@ export function removeLayerTargets(data, layer) {
     if (key.startsWith(`${layer}.`)) delete data.Targets[key];
   });
 }
+
+export function replaceLayerTargets(data, layer, entries) {
+  if (!data.Targets) data.Targets = {};
+  Object.keys(data.Targets).forEach(key => {
+    if (key.startsWith(`${layer}.`)) delete data.Targets[key];
+  });
+  entries.forEach(({ key, value }) => {
+    data.Targets[key] = value;
+  });
+}

--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -3,6 +3,7 @@ import VirtualizedList from './VirtualizedList.jsx';
 
 export default function EntryList({
   title,
+  titleAction,
   items = [],
   renderRow,
   header,
@@ -62,9 +63,10 @@ export default function EntryList({
         ...(paperProps.sx || {}),
       }}
     >
-      <Typography variant="subtitle1" sx={{ mb: 1 }}>
-        {title}
-      </Typography>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="subtitle1">{title}</Typography>
+        {titleAction || null}
+      </Box>
       {header !== undefined ? header : defaultHeader}
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <VirtualizedList

--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -1,0 +1,167 @@
+import { Dialog, AppBar, Toolbar, IconButton, Typography, Button, Box, TextField } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import SaveIcon from '@mui/icons-material/Save';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useState, useEffect } from 'react';
+
+const keyRegex = /^\d{2}\.\d{4}$/;
+const hexRegex = /^[0-9A-Fa-f]{8}$/;
+
+function calcNextKey(entries, layerKey) {
+  const indices = entries.map(e => parseInt(e.key.split('.')[1], 10));
+  const max = indices.length ? Math.max(...indices) : -1;
+  const next = max + 1;
+  return `${layerKey}.${String(next).padStart(4, '0')}`;
+}
+
+function calcOffset(index, hex) {
+  const dec = parseInt(index, 10);
+  const val = parseInt(hex, 16);
+  return dec - val;
+}
+
+function calcNextHex(entries, layerKey) {
+  if (!entries.length) return '00000000';
+  const sorted = [...entries].sort((a, b) => parseInt(a.key.split('.')[1], 10) - parseInt(b.key.split('.')[1], 10));
+  const last = sorted[sorted.length - 1];
+  const lastOffset = calcOffset(last.key.split('.')[1], last.value);
+  const nextIndex = parseInt(calcNextKey(entries, layerKey).split('.')[1], 10);
+  const nextVal = (nextIndex - lastOffset).toString(16).toUpperCase().padStart(8, '0');
+  return nextVal;
+}
+
+export default function EntryEditModal({ open, onClose, layerKey, layerLabel, entries = [], onSave, type }) {
+  const [rows, setRows] = useState([]);
+  const [newKey, setNewKey] = useState('');
+  const [newHex, setNewHex] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      const copy = entries.map(e => ({ ...e }));
+      setRows(copy);
+      setNewKey(calcNextKey(copy, layerKey));
+      setNewHex(calcNextHex(copy, layerKey));
+    }
+  }, [open, entries, layerKey]);
+
+  const handleRowChange = (idx, field, value) => {
+    const updated = rows.slice();
+    updated[idx] = { ...updated[idx], [field]: value };
+    if (field === 'key' || field === 'value') {
+      const indexPart = updated[idx].key.split('.')[1] || '0';
+      const hex = updated[idx].value || '0';
+      updated[idx].offset = calcOffset(indexPart, hex);
+    }
+    setRows(updated);
+  };
+
+  const handleDeleteRow = idx => {
+    const updated = rows.slice();
+    updated.splice(idx, 1);
+    setRows(updated);
+  };
+
+  const handleAdd = () => {
+    if (!keyRegex.test(newKey) || !hexRegex.test(newHex)) return;
+    if (rows.some(r => r.key === newKey)) return;
+    const indexPart = newKey.split('.')[1];
+    const offset = calcOffset(indexPart, newHex);
+    const updated = [...rows, { key: newKey, value: newHex.toUpperCase(), offset }];
+    setRows(updated);
+    const next = calcNextKey(updated, layerKey);
+    setNewKey(next);
+    setNewHex(calcNextHex(updated, layerKey));
+  };
+
+  const handleSave = () => {
+    if (onSave) {
+      onSave(rows.map(r => ({ key: r.key, value: r.value })));
+    }
+    onClose();
+  };
+
+  return (
+    <Dialog fullScreen open={open} onClose={onClose}>
+      <AppBar sx={{ position: 'relative' }}>
+        <Toolbar>
+          <IconButton edge="start" color="inherit" onClick={onClose} aria-label="close">
+            <CloseIcon />
+          </IconButton>
+          <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
+            {layerLabel} - Editing {type}
+          </Typography>
+          <Button color="inherit" startIcon={<SaveIcon />} onClick={handleSave}>
+            Save
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse' }}>
+          <Box component="thead">
+            <Box component="tr">
+              <Box component="th" sx={{ textAlign: 'left', px: 1 }}>Key</Box>
+              <Box component="th" sx={{ textAlign: 'left', px: 1 }}>Value</Box>
+              <Box component="th" sx={{ textAlign: 'right', px: 1 }}>Offset</Box>
+              <Box component="th" />
+            </Box>
+          </Box>
+          <Box component="tbody">
+            {rows.map((row, idx) => (
+              <Box component="tr" key={idx}>
+                <Box component="td" sx={{ px: 1 }}>
+                  <TextField
+                    size="small"
+                    value={row.key}
+                    error={!keyRegex.test(row.key)}
+                    onChange={e => handleRowChange(idx, 'key', e.target.value)}
+                  />
+                </Box>
+                <Box component="td" sx={{ px: 1 }}>
+                  <TextField
+                    size="small"
+                    value={row.value}
+                    error={!hexRegex.test(row.value)}
+                    onChange={e => handleRowChange(idx, 'value', e.target.value.toUpperCase())}
+                  />
+                </Box>
+                <Box component="td" sx={{ textAlign: 'right', px: 1, fontFamily: '"JetBrains Mono", monospace' }}>
+                  {row.offset}
+                </Box>
+                <Box component="td" sx={{ px: 1 }}>
+                  <IconButton onClick={() => handleDeleteRow(idx)} size="small">
+                    <DeleteIcon />
+                  </IconButton>
+                </Box>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <TextField
+            label="Key"
+            size="small"
+            value={newKey}
+            error={!keyRegex.test(newKey) || rows.some(r => r.key === newKey)}
+            onChange={e => setNewKey(e.target.value)}
+          />
+          <TextField
+            label="Hex"
+            size="small"
+            value={newHex}
+            error={!hexRegex.test(newHex)}
+            onChange={e => setNewHex(e.target.value.toUpperCase())}
+          />
+          <Typography sx={{ minWidth: 80, fontFamily: '"JetBrains Mono", monospace' }}>
+            {hexRegex.test(newHex) && keyRegex.test(newKey)
+              ? calcOffset(newKey.split('.')[1], newHex)
+              : ''}
+          </Typography>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={handleAdd}>
+            Add Entry
+          </Button>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,7 +1,9 @@
-import { Box } from '@mui/material';
-import { memo } from 'react';
+import { Box, Button } from '@mui/material';
+import { memo, useState } from 'react';
 import EntryList from '../Common/EntryList.jsx';
 import LayerList from './LayerList.jsx';
+import EntryEditModal from './EntryEditModal.jsx';
+import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 const LayerPanel = ({
   layers,
   targets,
@@ -10,19 +12,64 @@ const LayerPanel = ({
   onSelectLayer,
   onDeleteLayer,
   onError,
-}) => (
-  <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
-    <LayerList
-      layers={layers}
-      selected={selectedLayer}
-      onSelect={onSelectLayer}
-      onDelete={onDeleteLayer}
-      onError={onError}
-    />
-    <EntryList title="Targets" items={targets} />
-    <EntryList title="Sources" items={sources} />
-  </Box>
-);
+  onEditTargets,
+  onEditSources,
+}) => {
+  const [editType, setEditType] = useState(null);
+
+  const layer = layers.find(l => l.key === selectedLayer);
+
+  const handleClose = () => setEditType(null);
+
+  const openTargets = () => {
+    setEditType('Targets');
+  };
+  const openSources = () => {
+    setEditType('Sources');
+  };
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
+        <LayerList
+          layers={layers}
+          selected={selectedLayer}
+          onSelect={onSelectLayer}
+          onDelete={onDeleteLayer}
+          onError={onError}
+        />
+        <EntryList
+          title="Targets"
+          items={targets}
+          titleAction={<Button onClick={openTargets}>Edit</Button>}
+        />
+        <EntryList
+          title="Sources"
+          items={sources}
+          titleAction={<Button onClick={openSources}>Edit</Button>}
+        />
+      </Box>
+      {editType && layer && (
+        <EntryEditModal
+          open
+          type={editType}
+          layerKey={layer.key}
+          layerLabel={formatLayerLabel(layer.key, layer.value)}
+          entries={editType === 'Targets' ? targets : sources}
+          onClose={handleClose}
+          onSave={entries => {
+            if (editType === 'Targets') {
+              onEditTargets && onEditTargets(entries);
+            } else {
+              onEditSources && onEditSources(entries);
+            }
+            handleClose();
+          }}
+        />
+      )}
+    </>
+  );
+};
 
 export default memo(LayerPanel);
 

--- a/client/src/hooks/useMappingEditor.js
+++ b/client/src/hooks/useMappingEditor.js
@@ -6,10 +6,12 @@ import { loadState, saveState, clearState } from '../StorageAgent.js';
 import {
   groupTargetsByLayer,
   removeLayerTargets,
+  replaceLayerTargets,
 } from '../TargetsAgent.js';
 import {
   groupSourcesByLayer,
   removeLayerSources,
+  replaceLayerSources,
 } from '../SourcesAgent.js';
 
 export default function useMappingEditor() {
@@ -124,6 +126,32 @@ export default function useMappingEditor() {
     setSelectedLayer(nextKey);
   }, [iniData, layers]);
 
+  const replaceTargetsForLayer = useCallback(
+    (layer, entries) => {
+      const dataCopy = {
+        ...iniData,
+        Targets: { ...iniData.Targets },
+      };
+      replaceLayerTargets(dataCopy, layer, entries);
+      setIniData(dataCopy);
+      setTargets(groupTargetsByLayer(dataCopy));
+    },
+    [iniData],
+  );
+
+  const replaceSourcesForLayer = useCallback(
+    (layer, entries) => {
+      const dataCopy = {
+        ...iniData,
+        Sources: { ...iniData.Sources },
+      };
+      replaceLayerSources(dataCopy, layer, entries);
+      setIniData(dataCopy);
+      setSources(groupSourcesByLayer(dataCopy));
+    },
+    [iniData],
+  );
+
   const reset = useCallback(() => {
     setIniData(null);
     setLayers([]);
@@ -153,6 +181,8 @@ export default function useMappingEditor() {
     handlePathChange,
     handleAddLayer,
     handleRemoveLayer,
+    replaceTargetsForLayer,
+    replaceSourcesForLayer,
     reset,
   };
 }


### PR DESCRIPTION
## Summary
- create `EntryEditModal` for editing per-layer entries
- allow editing Targets and Sources from `LayerPanel`
- track entry updates via `useMappingEditor`
- add utility functions to replace target/source entries
- adjust `EntryList` for optional title actions

## Testing
- `npm install --ignore-scripts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68694e0572b8832fa938b96ea1d0a789