### PR TITLE
Add modal editor for targets and sources

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,8 @@ export default function App({ mode, toggleMode }) {
     handlePathChange,
     handleAddLayer,
     handleRemoveLayer,
+    updateLayerTargets,
+    updateLayerSources,
     reset,
   } = useMappingEditor();
 
@@ -63,6 +65,8 @@ export default function App({ mode, toggleMode }) {
               onSelectLayer={setSelectedLayer}
               onDeleteLayer={handleRemoveLayer}
               onError={setStatus}
+              onSaveTargets={updateLayerTargets}
+              onSaveSources={updateLayerSources}
             />
           </Box>
         </Container>

--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -7,6 +7,7 @@ export default function EntryList({
   renderRow,
   header,
   footer,
+  titleAction,
   itemHeight = 36,
   paperProps = {},
 }) {
@@ -62,9 +63,12 @@ export default function EntryList({
         ...(paperProps.sx || {}),
       }}
     >
-      <Typography variant="subtitle1" sx={{ mb: 1 }}>
-        {title}
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+        <Typography variant="subtitle1" sx={{ flex: 1 }}>
+          {title}
+        </Typography>
+        {titleAction || null}
+      </Box>
       {header !== undefined ? header : defaultHeader}
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <VirtualizedList

--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -1,0 +1,166 @@
+import {
+  Dialog,
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Box,
+  Button,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Checkbox,
+  TextField,
+  Paper,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { useState, useEffect } from 'react';
+
+function computeOffset(key, value) {
+  const [, indexPart] = key.split('.');
+  const decIndex = parseInt(indexPart, 10);
+  const hexVal = parseInt(value, 16);
+  return decIndex - hexVal;
+}
+
+export default function EntryEditModal({
+  open,
+  onClose,
+  title,
+  entries: initial,
+  onSave,
+}) {
+  const [rows, setRows] = useState([]);
+  const [selected, setSelected] = useState([]);
+
+  useEffect(() => {
+    if (open) {
+      setRows(initial.map(e => ({ ...e })));
+      setSelected([]);
+    }
+  }, [open, initial]);
+
+  const handleFieldChange = (idx, field, value) => {
+    setRows(r => {
+      const copy = [...r];
+      copy[idx] = { ...copy[idx], [field]: value };
+      return copy;
+    });
+  };
+
+  const handleAddRow = () => {
+    setRows(r => [
+      ...r,
+      { key: '', value: '', offset: 0 },
+    ]);
+  };
+
+  const handleDelete = () => {
+    setRows(r => r.filter((_row, i) => !selected.includes(i)));
+    setSelected([]);
+  };
+
+  const handleSave = () => {
+    const cleaned = rows.map(r => ({
+      key: r.key.trim(),
+      value: r.value.trim().toUpperCase(),
+    }));
+    onSave && onSave(cleaned);
+  };
+
+  const toggleSelect = idx => {
+    setSelected(s =>
+      s.includes(idx) ? s.filter(i => i !== idx) : [...s, idx]
+    );
+  };
+
+  return (
+    <Dialog fullScreen open={open} onClose={onClose}>
+      <AppBar sx={{ position: 'relative' }}>
+        <Toolbar>
+          <IconButton edge="start" color="inherit" onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+          <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
+            {title}
+          </Typography>
+          <Button color="inherit" onClick={handleSave}>
+            Save
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Box sx={{ p: 2, display: 'flex', height: '100%', boxSizing: 'border-box' }}>
+        <Box sx={{ flex: 1, overflow: 'auto' }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox" />
+                <TableCell>Key</TableCell>
+                <TableCell>Value</TableCell>
+                <TableCell align="right">Offset</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row, idx) => (
+                <TableRow key={idx} selected={selected.includes(idx)}>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selected.includes(idx)}
+                      onChange={() => toggleSelect(idx)}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ width: '30%' }}>
+                    <TextField
+                      fullWidth
+                      variant="standard"
+                      value={row.key}
+                      onChange={e => handleFieldChange(idx, 'key', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell sx={{ width: '30%' }}>
+                    <TextField
+                      fullWidth
+                      variant="standard"
+                      value={row.value}
+                      onChange={e => handleFieldChange(idx, 'value', e.target.value)}
+                    />
+                  </TableCell>
+                  <TableCell align="right" sx={{ width: '20%' }}>
+                    <Typography
+                      sx={{
+                        fontFamily: '"JetBrains Mono", monospace',
+                        color: computeOffset(row.key, row.value) === 0 ? 'success.dark' : 'error.dark',
+                      }}
+                    >
+                      {computeOffset(row.key, row.value)}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+        <Box sx={{ width: 200, pl: 2, display: 'flex', flexDirection: 'column' }}>
+          <Paper sx={{ p: 2, mb: 2 }}>
+            <Button startIcon={<AddIcon />} fullWidth onClick={handleAddRow}>
+              Add Entry
+            </Button>
+            <Button
+              startIcon={<DeleteIcon />}
+              fullWidth
+              disabled={selected.length === 0}
+              sx={{ mt: 1 }}
+              onClick={handleDelete}
+            >
+              Delete Selected
+            </Button>
+          </Paper>
+        </Box>
+      </Box>
+    </Dialog>
+  );
+}

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,7 +1,9 @@
-import { Box } from '@mui/material';
-import { memo } from 'react';
+import { Box, Button } from '@mui/material';
+import { memo, useState } from 'react';
 import EntryList from '../Common/EntryList.jsx';
 import LayerList from './LayerList.jsx';
+import EntryEditModal from './EntryEditModal.jsx';
+import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 const LayerPanel = ({
   layers,
   targets,
@@ -10,19 +12,68 @@ const LayerPanel = ({
   onSelectLayer,
   onDeleteLayer,
   onError,
-}) => (
-  <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
-    <LayerList
-      layers={layers}
-      selected={selectedLayer}
-      onSelect={onSelectLayer}
-      onDelete={onDeleteLayer}
-      onError={onError}
-    />
-    <EntryList title="Targets" items={targets} />
-    <EntryList title="Sources" items={sources} />
-  </Box>
-);
+  onSaveTargets,
+  onSaveSources,
+}) => {
+  const [editing, setEditing] = useState(null);
+
+  const currentLayer = layers.find(l => l.key === selectedLayer);
+
+  const handleSave = entries => {
+    if (editing === 'targets' && onSaveTargets) {
+      onSaveTargets(selectedLayer, entries);
+    }
+    if (editing === 'sources' && onSaveSources) {
+      onSaveSources(selectedLayer, entries);
+    }
+    setEditing(null);
+  };
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
+        <LayerList
+          layers={layers}
+          selected={selectedLayer}
+          onSelect={onSelectLayer}
+          onDelete={onDeleteLayer}
+          onError={onError}
+        />
+        <EntryList
+          title="Targets"
+          items={targets}
+          titleAction={
+            <Button size="small" variant="contained" onClick={() => setEditing('targets')}>
+              Edit
+            </Button>
+          }
+        />
+        <EntryList
+          title="Sources"
+          items={sources}
+          titleAction={
+            <Button size="small" variant="contained" onClick={() => setEditing('sources')}>
+              Edit
+            </Button>
+          }
+        />
+      </Box>
+      <EntryEditModal
+        open={Boolean(editing)}
+        title={
+          currentLayer
+            ? `${formatLayerLabel(currentLayer.key, currentLayer.value)} - Editing ${
+                editing === 'targets' ? 'Targets' : 'Sources'
+              }`
+            : ''
+        }
+        entries={editing === 'targets' ? targets : sources}
+        onClose={() => setEditing(null)}
+        onSave={handleSave}
+      />
+    </>
+  );
+};
 
 export default memo(LayerPanel);
 

--- a/client/src/hooks/useMappingEditor.js
+++ b/client/src/hooks/useMappingEditor.js
@@ -124,6 +124,44 @@ export default function useMappingEditor() {
     setSelectedLayer(nextKey);
   }, [iniData, layers]);
 
+  const updateLayerTargets = useCallback(
+    (layerKey, entries) => {
+      const dataCopy = {
+        ...iniData,
+        Targets: { ...iniData.Targets },
+      };
+      // Remove old entries for layer
+      Object.keys(dataCopy.Targets || {}).forEach(k => {
+        if (k.startsWith(`${layerKey}.`)) delete dataCopy.Targets[k];
+      });
+      // Add new entries
+      entries.forEach(e => {
+        dataCopy.Targets[e.key] = e.value;
+      });
+      setIniData(dataCopy);
+      setTargets(groupTargetsByLayer(dataCopy));
+    },
+    [iniData]
+  );
+
+  const updateLayerSources = useCallback(
+    (layerKey, entries) => {
+      const dataCopy = {
+        ...iniData,
+        Sources: { ...iniData.Sources },
+      };
+      Object.keys(dataCopy.Sources || {}).forEach(k => {
+        if (k.startsWith(`${layerKey}.`)) delete dataCopy.Sources[k];
+      });
+      entries.forEach(e => {
+        dataCopy.Sources[e.key] = e.value;
+      });
+      setIniData(dataCopy);
+      setSources(groupSourcesByLayer(dataCopy));
+    },
+    [iniData]
+  );
+
   const reset = useCallback(() => {
     setIniData(null);
     setLayers([]);
@@ -153,6 +191,8 @@ export default function useMappingEditor() {
     handlePathChange,
     handleAddLayer,
     handleRemoveLayer,
+    updateLayerTargets,
+    updateLayerSources,
     reset,
   };
 }


### PR DESCRIPTION
## Summary
- allow optional actions in `EntryList`
- add full-screen `EntryEditModal`
- wire layer panel to launch modal editors
- extend mapping editor hook to update targets and sources
- pass new handlers from `App`

## Testing
- `npm --prefix client run lint`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_686959a938c0832faf31b11c75449108