### PR TITLE
Fix entry editor layout and adjust add layer button

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -99,7 +99,12 @@ export default function EntryEditModal({
   const valRegex = /^[0-9A-Fa-f]{8}$/;
 
   return (
-    <Dialog fullScreen open={open} onClose={onClose}>
+    <Dialog
+      fullScreen
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { display: 'flex', flexDirection: 'column' } }}
+    >
       <AppBar sx={{ position: 'relative' }}>
         <Toolbar>
           <Typography sx={{ flex: 1 }} variant="h6" component="div">
@@ -110,7 +115,7 @@ export default function EntryEditModal({
           </IconButton>
         </Toolbar>
       </AppBar>
-      <Box sx={{ display: 'flex', height: '100%' }}>
+      <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         <Box sx={{ flex: 1, p: 2, overflow: 'auto' }}>
           <Box sx={{ display: 'flex', fontWeight: 'bold', mb: 1, fontFamily: '"JetBrains Mono", monospace' }}>
             <Box sx={{ width: '40%' }}>Key</Box>

--- a/client/src/components/Editor/LayerPathRow.jsx
+++ b/client/src/components/Editor/LayerPathRow.jsx
@@ -1,5 +1,4 @@
 import { Paper, Box, Typography, TextField, Button } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import { memo } from 'react';
 
 const LayerPathRow = ({ layer, onPathChange, onAdd }) => {
@@ -20,8 +19,8 @@ const LayerPathRow = ({ layer, onPathChange, onAdd }) => {
         {onAdd && (
           <Button
             variant="contained"
-            startIcon={<AddIcon />}
             onClick={onAdd}
+            sx={{ whiteSpace: 'nowrap' }}
           >
             Add Layer
           </Button>


### PR DESCRIPTION
## Summary
- keep Add Layer button on one line by removing icon and preventing text wrap
- update the fullscreen entry editor dialog layout so actions remain visible

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686963f3f6e8832fbef83782f2537134