### PR TITLE
Reuse header style in editor modal

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -1,7 +1,5 @@
 import {
   Dialog,
-  AppBar,
-  Toolbar,
   Typography,
   IconButton,
   Box,
@@ -14,6 +12,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useEffect, useState } from 'react';
+import { HeaderBar } from '../Layout/Header.jsx';
 
 export default function EntryEditModal({
   open,
@@ -105,16 +104,14 @@ export default function EntryEditModal({
       onClose={onClose}
       PaperProps={{ sx: { display: 'flex', flexDirection: 'column' } }}
     >
-      <AppBar sx={{ position: 'relative' }}>
-        <Toolbar>
-          <Typography sx={{ flex: 1 }} variant="h6" component="div">
-            {layerLabel} - Editing {type}
-          </Typography>
-          <IconButton edge="end" color="inherit" onClick={onClose}>
-            <CloseIcon />
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+      <HeaderBar sx={{ position: 'relative' }}>
+        <Typography sx={{ flex: 1 }} variant="h6" component="div">
+          {layerLabel} - Editing {type}
+        </Typography>
+        <IconButton edge="end" color="inherit" onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </HeaderBar>
       <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         <Box sx={{ flex: 1, p: 2, overflow: 'auto' }}>
           <Box sx={{ display: 'flex', fontWeight: 'bold', mb: 1, fontFamily: '"JetBrains Mono", monospace' }}>

--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -3,29 +3,44 @@ import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import FileUpload from '../Common/FileUpload.jsx';
 
-const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, loading }) => (
-  <AppBar position="static" sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}>
-    <Toolbar sx={{ gap: 2, minHeight: 64 }}>
-      <Typography
-        variant="h4"
-        component="div"
-        sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', mr: 2 }}
-      >
-        Mappy
-      </Typography>
-      <Box sx={{ flexGrow: 1 }} />
-      <FileUpload onFileSelect={onFileSelect} />
-      <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>
-        Download
-      </Button>
-      <Button color="inherit" onClick={onReset} disabled={loading}>
-        Reset
-      </Button>
-      <IconButton color="inherit" onClick={toggleMode} aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
-        {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
-      </IconButton>
+export const HeaderBar = ({ children, toolbarProps = {}, ...appBarProps }) => (
+  <AppBar
+    position="static"
+    sx={{
+      background: 'linear-gradient(90deg,#283593,#8e24aa)',
+      borderBottom: 1,
+      borderColor: 'divider',
+      ...(appBarProps.sx || {}),
+    }}
+    {...appBarProps}
+  >
+    <Toolbar sx={{ gap: 2, minHeight: 64, ...(toolbarProps.sx || {}) }} {...toolbarProps}>
+      {children}
     </Toolbar>
   </AppBar>
+);
+
+const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, loading }) => (
+  <HeaderBar>
+    <Typography
+      variant="h4"
+      component="div"
+      sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', mr: 2 }}
+    >
+      Mappy
+    </Typography>
+    <Box sx={{ flexGrow: 1 }} />
+    <FileUpload onFileSelect={onFileSelect} />
+    <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>
+      Download
+    </Button>
+    <Button color="inherit" onClick={onReset} disabled={loading}>
+      Reset
+    </Button>
+    <IconButton color="inherit" onClick={toggleMode} aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
+      {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+    </IconButton>
+  </HeaderBar>
 );
 
 export default Header;


### PR DESCRIPTION
## Summary
- extract `HeaderBar` from `Header` for reuse
- use `HeaderBar` inside `EntryEditModal`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68696ae2a918832fbe6536331df52f63