### PR TITLE
Unify modal and main header appearance

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -1,7 +1,5 @@
 import {
   Dialog,
-  AppBar,
-  Toolbar,
   Typography,
   IconButton,
   Box,
@@ -14,6 +12,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useEffect, useState } from 'react';
+import AppToolbar from '../Layout/AppToolbar.jsx';
 
 export default function EntryEditModal({
   open,
@@ -105,16 +104,18 @@ export default function EntryEditModal({
       onClose={onClose}
       PaperProps={{ sx: { display: 'flex', flexDirection: 'column' } }}
     >
-      <AppBar sx={{ position: 'relative' }}>
-        <Toolbar>
-          <Typography sx={{ flex: 1 }} variant="h6" component="div">
-            {layerLabel} - Editing {type}
-          </Typography>
-          <IconButton edge="end" color="inherit" onClick={onClose}>
-            <CloseIcon />
-          </IconButton>
-        </Toolbar>
-      </AppBar>
+      <AppToolbar position="relative">
+        <Typography
+          sx={{ flex: 1, fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold' }}
+          variant="h6"
+          component="div"
+        >
+          {layerLabel} - Editing {type}
+        </Typography>
+        <IconButton edge="end" color="inherit" onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </AppToolbar>
       <Box sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
         <Box sx={{ flex: 1, p: 2, overflow: 'auto' }}>
           <Box sx={{ display: 'flex', fontWeight: 'bold', mb: 1, fontFamily: '"JetBrains Mono", monospace' }}>

--- a/client/src/components/Layout/AppToolbar.jsx
+++ b/client/src/components/Layout/AppToolbar.jsx
@@ -1,0 +1,12 @@
+import { AppBar, Toolbar } from '@mui/material';
+
+const AppToolbar = ({ position = 'static', children }) => (
+  <AppBar
+    position={position}
+    sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}
+  >
+    <Toolbar sx={{ gap: 2, minHeight: 64 }}>{children}</Toolbar>
+  </AppBar>
+);
+
+export default AppToolbar;

--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -1,31 +1,30 @@
-import { AppBar, Toolbar, Button, IconButton, Box, Typography } from '@mui/material';
+import { Button, IconButton, Box, Typography } from '@mui/material';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import FileUpload from '../Common/FileUpload.jsx';
+import AppToolbar from './AppToolbar.jsx';
 
 const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, loading }) => (
-  <AppBar position="static" sx={{ background: 'linear-gradient(90deg,#283593,#8e24aa)', borderBottom: 1, borderColor: 'divider' }}>
-    <Toolbar sx={{ gap: 2, minHeight: 64 }}>
-      <Typography
-        variant="h4"
-        component="div"
-        sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', mr: 2 }}
-      >
-        Mappy
-      </Typography>
-      <Box sx={{ flexGrow: 1 }} />
-      <FileUpload onFileSelect={onFileSelect} />
-      <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>
-        Download
-      </Button>
-      <Button color="inherit" onClick={onReset} disabled={loading}>
-        Reset
-      </Button>
-      <IconButton color="inherit" onClick={toggleMode} aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
-        {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
-      </IconButton>
-    </Toolbar>
-  </AppBar>
+  <AppToolbar>
+    <Typography
+      variant="h4"
+      component="div"
+      sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', mr: 2 }}
+    >
+      Mappy
+    </Typography>
+    <Box sx={{ flexGrow: 1 }} />
+    <FileUpload onFileSelect={onFileSelect} />
+    <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>
+      Download
+    </Button>
+    <Button color="inherit" onClick={onReset} disabled={loading}>
+      Reset
+    </Button>
+    <IconButton color="inherit" onClick={toggleMode} aria-label={mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}>
+      {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+    </IconButton>
+  </AppToolbar>
 );
 
 export default Header;


### PR DESCRIPTION
## Summary
- share layout styling via new `AppToolbar`
- reuse `AppToolbar` in main layout `Header`
- style entry edit modal header using the shared toolbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68696ae2a918832fbe6536331df52f63