### PR TITLE
Add app name to editor modal header

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -106,6 +106,13 @@ export default function EntryEditModal({
     >
       <AppToolbar position="relative">
         <Typography
+          variant="h4"
+          component="div"
+          sx={{ fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold', mr: 2 }}
+        >
+          Mappy
+        </Typography>
+        <Typography
           sx={{ flex: 1, fontFamily: '"Baloo 2", sans-serif', fontWeight: 'bold' }}
           variant="h6"
           component="div"


### PR DESCRIPTION
## Summary
- show "Mappy" on the left side of the entry editor modal header
- keep layer name and type text to the right of the app name

## Testing
- `npm --prefix client run lint`

------
https://chatgpt.com/codex/tasks/task_e_68696cef77ec832f867be5ec9b019ee5