### PR TITLE
Add global search feature

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { Box, Container, Snackbar, Typography } from '@mui/material';
 import LayerPanel from './components/Editor/LayerPanel.jsx';
 import LayerPathRow from './components/Editor/LayerPathRow.jsx';
 import Header from './components/Layout/Header.jsx';
+import { SearchProvider } from './hooks/useSearch.jsx';
 import useMappingEditor from './hooks/useMappingEditor.js';
 
 export default function App({ mode, toggleMode }) {
@@ -26,16 +27,23 @@ export default function App({ mode, toggleMode }) {
   } = useMappingEditor();
 
   return (
-    <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <Header
-        mode={mode}
-        toggleMode={toggleMode}
-        iniData={iniData}
-        onFileSelect={handleFileChange}
-        onDownload={download}
-        onReset={reset}
-        loading={loading}
-      />
+    <SearchProvider
+      layers={layers}
+      targets={targets}
+      sources={sources}
+      selectedLayer={selectedLayer}
+      setSelectedLayer={setSelectedLayer}
+    >
+      <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+        <Header
+          mode={mode}
+          toggleMode={toggleMode}
+          iniData={iniData}
+          onFileSelect={handleFileChange}
+          onDownload={download}
+          onReset={reset}
+          loading={loading}
+        />
       {iniData ? (
         <Container
           maxWidth={false}
@@ -85,5 +93,6 @@ export default function App({ mode, toggleMode }) {
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       />
     </Box>
+    </SearchProvider>
   );
 }

--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -1,5 +1,7 @@
 import { Box, ListItemButton, Paper, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import VirtualizedList from './VirtualizedList.jsx';
+import { useSearch } from '../../hooks/useSearch.jsx';
 
 export default function EntryList({
   title,
@@ -18,6 +20,10 @@ export default function EntryList({
     </Box>
   );
 
+  const { query, matchSet, currentResult } = useSearch() || {};
+  const theme = useTheme();
+  const highlight = theme.palette.mode === 'light' ? '#fff59d' : '#f9a825';
+
   const defaultRow = (item, _i, style) => (
     <Box style={style} key={item.key}>
       <ListItemButton
@@ -27,7 +33,13 @@ export default function EntryList({
           py: 0,
           mb: 0.5,
           borderRadius: 1,
+          transition: 'background-color 0.3s',
           '&.Mui-selected': { bgcolor: 'action.selected' },
+          ...(matchSet?.has(item.key) && { bgcolor: highlight }),
+          ...(query && !matchSet?.has(item.key) && { opacity: 0.7 }),
+          ...(currentResult?.key === item.key && {
+            animation: 'pulseHighlight 1.5s infinite',
+          }),
         }}
       >
         <Box sx={{ display: 'flex', width: '100%' }}>

--- a/client/src/components/Common/SearchField.jsx
+++ b/client/src/components/Common/SearchField.jsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import {
+  Box,
+  IconButton,
+  InputBase,
+  Paper,
+  Typography,
+  ClickAwayListener,
+} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+import CloseIcon from '@mui/icons-material/Close';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { useSearch } from '../../hooks/useSearch.jsx';
+
+export default function SearchField() {
+  const search = useSearch();
+  const [open, setOpen] = useState(false);
+
+  if (!search) return null;
+  const { query, setQuery, results, current, next, prev } = search;
+
+  const handleAway = () => {
+    if (!query) setOpen(false);
+  };
+
+  return (
+    <ClickAwayListener onClickAway={handleAway}>
+      <Box sx={{ display: 'flex', alignItems: 'center', position: 'relative' }}>
+        {open ? (
+          <Paper
+            sx={theme => ({
+              width: 300,
+              px: 1,
+              py: 0.5,
+              display: 'flex',
+              alignItems: 'center',
+              transition: 'width 0.2s',
+              backgroundColor:
+                theme.palette.mode === 'light' ? '#fff' : theme.palette.grey[800],
+            })}
+          >
+            <SearchIcon sx={{ mr: 1 }} />
+            <InputBase
+              autoFocus
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search layers, targets, sources..."
+              sx={{ flex: 1 }}
+            />
+            {query && (
+              <IconButton size="small" onClick={() => setQuery('')}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            )}
+          </Paper>
+        ) : (
+          <IconButton color="inherit" onClick={() => setOpen(true)}>
+            <SearchIcon />
+          </IconButton>
+        )}
+        {open && results.length > 0 && (
+          <Box sx={{ display: 'flex', alignItems: 'center', ml: 1 }}>
+            <Typography variant="caption" sx={{ px: 1 }}>
+              {`${current + 1} of ${results.length}`}
+            </Typography>
+            <IconButton size="small" onClick={prev}>
+              <KeyboardArrowUpIcon fontSize="small" />
+            </IconButton>
+            <IconButton size="small" onClick={next}>
+              <KeyboardArrowDownIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        )}
+      </Box>
+    </ClickAwayListener>
+  );
+}

--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -16,6 +16,8 @@ import {
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { memo, useLayoutEffect, useRef, useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+import { useSearch } from '../../hooks/useSearch.jsx';
 import EntryList from '../Common/EntryList.jsx';
 import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
 
@@ -27,58 +29,71 @@ const LayerList = ({ layers = [], selected, onSelect, onDelete, onError }) => {
   const [activeMenuLayer, setActiveMenuLayer] = useState(null);
   const [confirmLayer, setConfirmLayer] = useState(null);
 
-  const renderRow = (layer, _i, style) => (
-    <Box
-      style={style}
-      key={layer.key}
-      sx={{ position: 'relative', '&:hover .layer-menu-btn': { opacity: 1 } }}
-    >
-      <ListItemButton
-        selected={layer.key === selected}
-        onClick={() => onSelect(layer.key)}
-        sx={{
-          height: '100%',
-          minHeight: 0,
-          py: 0,
-          pr: 4,
-          mb: 0.5,
-          borderRadius: 1,
-          '&.Mui-selected': { bgcolor: 'action.selected' },
-        }}
+  const { query, matchSet, currentResult, counts } = useSearch() || {};
+  const theme = useTheme();
+  const highlight =
+    theme.palette.mode === 'light' ? '#fff59d' : '#f9a825';
+
+  const renderRow = (layer, _i, style) => {
+    const isMatch = matchSet?.has(layer.key);
+    const isCurrent = currentResult?.key === layer.key;
+    return (
+      <Box
+        style={style}
+        key={layer.key}
+        sx={{ position: 'relative', '&:hover .layer-menu-btn': { opacity: 1 } }}
       >
-        <ListItemText
-          primary={formatLayerLabel(layer.key, layer.value)}
-          primaryTypographyProps={{
-            noWrap: true,
-            sx: { fontFamily: '"JetBrains Mono", monospace' },
+        <ListItemButton
+          selected={layer.key === selected}
+          onClick={() => onSelect(layer.key)}
+          sx={{
+            height: '100%',
+            minHeight: 0,
+            py: 0,
+            pr: 4,
+            mb: 0.5,
+            borderRadius: 1,
+            transition: 'background-color 0.3s',
+            '&.Mui-selected': { bgcolor: 'action.selected' },
+            ...(isMatch && { bgcolor: highlight }),
+            ...(query && !isMatch && { opacity: 0.7 }),
+            ...(isCurrent && { animation: 'pulseHighlight 1.5s infinite' }),
           }}
-        />
-      </ListItemButton>
-      <IconButton
-        className="layer-menu-btn"
-        size="small"
-        onClick={e => {
-          e.stopPropagation();
-          const rect = e.currentTarget.getBoundingClientRect();
-          setMenuPosition({ top: rect.bottom, left: rect.left });
-          setActiveMenuLayer(layer.key);
-        }}
-        sx={{
-          position: 'absolute',
-          right: 0,
-          top: '50%',
-          transform: 'translateY(-50%)',
-          opacity: 0,
-          transition: 'opacity 0.1s',
-          color: 'action.disabled',
-          p: '4px',
-          '&:hover': { color: 'action.active' },
-        }}
-      >
-        <MoreVertIcon fontSize="small" />
-      </IconButton>
-    </Box>
-  );
+        >
+          <ListItemText
+            primary={formatLayerLabel(layer.key, layer.value)}
+            primaryTypographyProps={{
+              noWrap: true,
+              sx: { fontFamily: '"JetBrains Mono", monospace' },
+            }}
+          />
+        </ListItemButton>
+        <IconButton
+          className="layer-menu-btn"
+          size="small"
+          onClick={e => {
+            e.stopPropagation();
+            const rect = e.currentTarget.getBoundingClientRect();
+            setMenuPosition({ top: rect.bottom, left: rect.left });
+            setActiveMenuLayer(layer.key);
+          }}
+          sx={{
+            position: 'absolute',
+            right: 0,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            opacity: 0,
+            transition: 'opacity 0.1s',
+            color: 'action.disabled',
+            p: '4px',
+            '&:hover': { color: 'action.active' },
+          }}
+        >
+          <MoreVertIcon fontSize="small" />
+        </IconButton>
+      </Box>
+    );
+  };
 
   const longestLabel = layers.reduce((acc, l) => {
     const label = formatLayerLabel(l.key, l.value);
@@ -173,7 +188,7 @@ const LayerList = ({ layers = [], selected, onSelect, onDelete, onError }) => {
         </ListItemButton>
       </Box>
       <EntryList
-        title="Layers"
+        title={`Layers${query ? ` (${counts?.layers || 0})` : ''}`}
         items={layers}
         renderRow={renderRow}
         header={header}

--- a/client/src/components/Editor/LayerPanel.jsx
+++ b/client/src/components/Editor/LayerPanel.jsx
@@ -1,5 +1,6 @@
 import { Box, Button } from '@mui/material';
 import { memo, useState } from 'react';
+import { useSearch } from '../../hooks/useSearch.jsx';
 import EntryList from '../Common/EntryList.jsx';
 import LayerList from './LayerList.jsx';
 import EntryEditModal from './EntryEditModal.jsx';
@@ -20,6 +21,8 @@ const LayerPanel = ({
 
   const layer = layers.find(l => l.key === selectedLayer);
   const label = layer ? formatLayerLabel(layer.key, layer.value) : '';
+  const { query, counts } = useSearch() || {};
+  const active = Boolean(query);
 
   return (
     <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
@@ -33,7 +36,7 @@ const LayerPanel = ({
       <EntryList
         title={
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            Targets
+            {`Targets${active ? ` (${counts?.targets || 0})` : ''}`}
             <Button variant="contained" size="small" onClick={() => setEditTargetsOpen(true)}>
               Edit
             </Button>
@@ -44,7 +47,7 @@ const LayerPanel = ({
       <EntryList
         title={
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            Sources
+            {`Sources${active ? ` (${counts?.sources || 0})` : ''}`}
             <Button variant="contained" size="small" onClick={() => setEditSourcesOpen(true)}>
               Edit
             </Button>

--- a/client/src/components/Layout/Header.jsx
+++ b/client/src/components/Layout/Header.jsx
@@ -2,6 +2,7 @@ import { Button, IconButton, Box, Typography } from '@mui/material';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import FileUpload from '../Common/FileUpload.jsx';
+import SearchField from '../Common/SearchField.jsx';
 import AppToolbar from './AppToolbar.jsx';
 
 const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, loading }) => (
@@ -13,6 +14,7 @@ const Header = ({ mode, toggleMode, iniData, onFileSelect, onDownload, onReset, 
     >
       Mappy
     </Typography>
+    <SearchField />
     <Box sx={{ flexGrow: 1 }} />
     <FileUpload onFileSelect={onFileSelect} />
     <Button variant="contained" onClick={onDownload} disabled={!iniData || loading}>

--- a/client/src/hooks/useSearch.jsx
+++ b/client/src/hooks/useSearch.jsx
@@ -1,0 +1,121 @@
+/* eslint react-refresh/only-export-components: off */
+import { createContext, useContext, useState, useMemo, useEffect } from 'react';
+
+function buildSearchIndex({ layers = [], targets = {}, sources = {} }) {
+  const index = [];
+  layers.forEach(l => {
+    index.push({
+      type: 'layer',
+      key: l.key,
+      value: l.value,
+      layerKey: l.key,
+      text: `${l.key} ${l.value}`,
+    });
+  });
+  Object.values(targets).forEach(arr => {
+    arr.forEach(t => {
+      index.push({
+        type: 'target',
+        key: t.key,
+        value: t.value,
+        layerKey: t.key.split('.')[0],
+        text: `${t.key} ${t.value}`,
+      });
+    });
+  });
+  Object.values(sources).forEach(arr => {
+    arr.forEach(s => {
+      index.push({
+        type: 'source',
+        key: s.key,
+        value: s.value,
+        layerKey: s.key.split('.')[0],
+        text: `${s.key} ${s.value}`,
+      });
+    });
+  });
+  return index;
+}
+
+const SearchContext = createContext(null);
+
+export function SearchProvider({
+  layers,
+  targets,
+  sources,
+  selectedLayer,
+  setSelectedLayer,
+  children,
+}) {
+  const index = useMemo(
+    () => buildSearchIndex({ layers, targets, sources }),
+    [layers, targets, sources]
+  );
+
+  const [query, setQuery] = useState('');
+  const [current, setCurrent] = useState(0);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    return index.filter(item => item.text.toLowerCase().includes(q));
+  }, [index, query]);
+
+  const matchSet = useMemo(() => new Set(results.map(r => r.key)), [results]);
+
+  useEffect(() => {
+    setCurrent(0);
+  }, [results]);
+
+  const counts = useMemo(() => {
+    const c = { layers: 0, targets: 0, sources: 0 };
+    results.forEach(r => {
+      if (r.type === 'layer') c.layers += 1;
+      else if (r.type === 'target') c.targets += 1;
+      else c.sources += 1;
+    });
+    return c;
+  }, [results]);
+
+  const currentResult = results[current] || null;
+
+  const next = () => {
+    if (results.length) setCurrent((current + 1) % results.length);
+  };
+  const prev = () => {
+    if (results.length)
+      setCurrent((current - 1 + results.length) % results.length);
+  };
+
+  useEffect(() => {
+    if (
+      currentResult &&
+      currentResult.layerKey !== selectedLayer &&
+      typeof setSelectedLayer === 'function'
+    ) {
+      setSelectedLayer(currentResult.layerKey);
+    }
+  }, [currentResult, selectedLayer, setSelectedLayer]);
+
+  return (
+    <SearchContext.Provider
+      value={{
+        query,
+        setQuery,
+        results,
+        counts,
+        current,
+        currentResult,
+        matchSet,
+        next,
+        prev,
+      }}
+    >
+      {children}
+    </SearchContext.Provider>
+  );
+}
+
+export function useSearch() {
+  return useContext(SearchContext);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -88,3 +88,16 @@ button:focus-visible {
 *::-webkit-scrollbar-track {
   background: transparent;
 }
+
+@keyframes pulseHighlight {
+  0% {
+    box-shadow: 0 0 0 0 rgba(249, 168, 37, 0.6);
+  }
+  50% {
+    box-shadow: 0 0 0 6px rgba(249, 168, 37, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(249, 168, 37, 0);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add search hook and provider to build global index
- expand toolbar with search field
- highlight search matches in lists and modal editor
- display result counts in panel headers
- animate highlights via CSS
- fix lint errors and file extension for search hook

## Testing
- `npm --prefix client run lint`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_68697c631b08832f93c33d9637c5101e