### PR TITLE
Sync highlight colors across editor views

### DIFF
--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -1,5 +1,5 @@
 import { Box, ListItemButton, Paper, Typography } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
+import useHighlightColors from '../../utils/useHighlightColors.js';
 import VirtualizedList from './VirtualizedList.jsx';
 import { useSearch } from '../../hooks/useSearch.jsx';
 
@@ -21,13 +21,7 @@ export default function EntryList({
   );
 
   const { query, matchSet, currentResult } = useSearch() || {};
-  const theme = useTheme();
-  const highlight = theme.palette.mode === 'light'
-    ? 'rgba(255, 245, 157, 0.3)'
-    : 'rgba(249, 168, 37, 0.15)';
-  const currentHighlight = theme.palette.mode === 'light'
-    ? 'rgba(255, 245, 157, 0.8)'
-    : 'rgba(249, 168, 37, 0.45)';
+  const { highlight, currentHighlight } = useHighlightColors();
 
   const defaultRow = (item, _i, style) => (
     <Box style={style} key={item.key}>

--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -12,7 +12,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useEffect, useState } from 'react';
-import { useTheme } from '@mui/material/styles';
+import useHighlightColors from '../../utils/useHighlightColors.js';
 import { useSearch } from '../../hooks/useSearch.jsx';
 import AppToolbar from '../Layout/AppToolbar.jsx';
 import SearchField from '../Common/SearchField.jsx';
@@ -100,20 +100,14 @@ export default function EntryEditModal({
   const keyRegex = /^\d{2}\.\d{4}$/;
   const valRegex = /^[0-9A-Fa-f]{8}$/;
   const { query, matchSet, currentResult } = useSearch() || {};
-  const theme = useTheme();
-  const highlight = theme.palette.mode === 'light'
-    ? 'rgba(255, 245, 157, 0.3)'
-    : 'rgba(249, 168, 37, 0.15)';
-  const currentHighlight = theme.palette.mode === 'light'
-    ? 'rgba(255, 245, 157, 0.8)'
-    : 'rgba(249, 168, 37, 0.45)';
+  const { highlight, currentHighlight } = useHighlightColors();
 
   return (
     <Dialog
         fullScreen
         open={open}
         onClose={onClose}
-        PaperProps={{ sx: { display: 'flex', flexDirection: 'column' } }}
+        PaperProps={{ sx: { display: 'flex', flexDirection: 'column', bgcolor: 'background.default' } }}
       >
         <AppToolbar position="relative">
           <Typography
@@ -157,6 +151,7 @@ export default function EntryEditModal({
                   py: 0.5,
                   bgcolor: selected.includes(i) ? 'action.selected' : undefined,
                   transition: 'background-color 0.3s',
+                  '&:hover': { bgcolor: 'action.hover' },
                   ...(isMatch && { bgcolor: highlight }),
                   ...(query && !isMatch && { opacity: 0.7 }),
                   ...(isCurrent && { bgcolor: currentHighlight }),

--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -16,7 +16,7 @@ import {
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { memo, useLayoutEffect, useRef, useState } from 'react';
-import { useTheme } from '@mui/material/styles';
+import useHighlightColors from '../../utils/useHighlightColors.js';
 import { useSearch } from '../../hooks/useSearch.jsx';
 import EntryList from '../Common/EntryList.jsx';
 import { formatLayerLabel } from '../../utils/formatLayerLabel.js';
@@ -30,13 +30,7 @@ const LayerList = ({ layers = [], selected, onSelect, onDelete, onError }) => {
   const [confirmLayer, setConfirmLayer] = useState(null);
 
   const { query, matchSet, currentResult, counts } = useSearch() || {};
-  const theme = useTheme();
-  const highlight = theme.palette.mode === 'light'
-    ? 'rgba(255, 245, 157, 0.3)'
-    : 'rgba(249, 168, 37, 0.15)';
-  const currentHighlight = theme.palette.mode === 'light'
-    ? 'rgba(255, 245, 157, 0.8)'
-    : 'rgba(249, 168, 37, 0.45)';
+  const { highlight, currentHighlight } = useHighlightColors();
 
   const renderRow = (layer, _i, style) => {
     const isMatch = matchSet?.has(layer.key);

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -4,8 +4,7 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* colors are provided by the MUI theme */
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -58,8 +57,7 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    /* theme controls text and background colors */
   }
   a:hover {
     color: #747bff;

--- a/client/src/utils/useHighlightColors.js
+++ b/client/src/utils/useHighlightColors.js
@@ -1,0 +1,12 @@
+import { useTheme } from '@mui/material/styles';
+
+export default function useHighlightColors() {
+  const theme = useTheme();
+  const highlight = theme.palette.mode === 'light'
+    ? 'rgba(255, 245, 157, 0.3)'
+    : 'rgba(249, 168, 37, 0.15)';
+  const currentHighlight = theme.palette.mode === 'light'
+    ? 'rgba(255, 245, 157, 0.8)'
+    : 'rgba(249, 168, 37, 0.45)';
+  return { highlight, currentHighlight };
+}


### PR DESCRIPTION
## Summary
- centralize highlight color logic in `useHighlightColors` hook
- apply consistent highlight and hover styles to `EntryList`, `LayerList`, and `EntryEditModal`
- rely on theme for background color so dialogs match main UI

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68698553a11c832f8279ea0bb52818d1