### PR TITLE
Fix edit modal list styles

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -148,7 +148,9 @@ export default function EntryEditModal({
                   display: 'flex',
                   alignItems: 'center',
                   px: 1,
-                  py: 0.5,
+                  py: 0,
+                  minHeight: 0,
+                  borderRadius: 1,
                   bgcolor: selected.includes(i) ? 'action.selected' : undefined,
                   transition: 'background-color 0.3s',
                   '&:hover': { bgcolor: 'action.hover' },
@@ -163,7 +165,10 @@ export default function EntryEditModal({
                 variant="standard"
                 error={!keyRegex.test(row.key)}
                 sx={{ width: '40%' }}
-                InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                InputProps={{
+                  disableUnderline: true,
+                  sx: { fontFamily: '"JetBrains Mono", monospace' },
+                }}
               />
               <TextField
                 value={row.value}
@@ -171,7 +176,10 @@ export default function EntryEditModal({
                 variant="standard"
                 error={!valRegex.test(row.value)}
                 sx={{ width: '40%' }}
-                InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                InputProps={{
+                  disableUnderline: true,
+                  sx: { fontFamily: '"JetBrains Mono", monospace' },
+                }}
               />
               <Box
                 sx={{


### PR DESCRIPTION
## Summary
- style entry editor rows like main UI lists
- remove text field underlines for cleaner look

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a423cdd40832f9b1d74559b3ff70b