### PR TITLE
Add batch transformation panel

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -7,15 +7,33 @@ import {
   TextField,
   DialogActions,
   Paper,
+  Tooltip,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Collapse,
+  RadioGroup,
+  Radio,
+  FormControlLabel,
+  Checkbox,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { useEffect, useState } from 'react';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useEffect, useState, useMemo } from 'react';
 import useHighlightColors from '../../utils/useHighlightColors.js';
 import { useSearch } from '../../hooks/useSearch.jsx';
 import AppToolbar from '../Layout/AppToolbar.jsx';
 import SearchField from '../Common/SearchField.jsx';
+
+const keyRegex = /^\d{2}\.\d{4}$/;
+const valRegex = /^[0-9A-Fa-f]{8}$/;
 
 export default function EntryEditModal({
   open,
@@ -32,6 +50,22 @@ export default function EntryEditModal({
   const [batchQty, setBatchQty] = useState(1);
   const [batchStart, setBatchStart] = useState(0);
   const [batchOffset, setBatchOffset] = useState(0);
+
+  const [transformType, setTransformType] = useState('Adjust Values');
+  const [adjustMode, setAdjustMode] = useState('add');
+  const [adjustAmount, setAdjustAmount] = useState(0);
+  const [skipZero, setSkipZero] = useState(false);
+
+  const [seqStart, setSeqStart] = useState(0);
+  const [seqIncrement, setSeqIncrement] = useState(1);
+  const [seqOrder, setSeqOrder] = useState('selection');
+
+  const [fixedValue, setFixedValue] = useState('00000000');
+
+  const [shiftDir, setShiftDir] = useState('up');
+  const [shiftAmount, setShiftAmount] = useState(1);
+
+  const [previewOpen, setPreviewOpen] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -92,15 +126,144 @@ export default function EntryEditModal({
     setBatchStart(nextStart);
   };
 
+  const applyTransform = () => {
+    if (!inputsValid) return;
+    const newRows = rows.slice();
+    const indices = [...selected];
+    if (transformType === 'Sequential Fill' && seqOrder === 'key') {
+      indices.sort((a, b) => {
+        const aVal = parseInt(rows[a].key.split('.')[1], 10);
+        const bVal = parseInt(rows[b].key.split('.')[1], 10);
+        return aVal - bVal;
+      });
+    }
+    indices.forEach((idx, i) => {
+      let { key, value } = newRows[idx];
+      if (transformType === 'Adjust Values') {
+        if (!(skipZero && newRows[idx].offset === 0)) {
+          const val = parseInt(value, 16) || 0;
+          const amt = parseInt(adjustAmount, 10) || 0;
+          const out = adjustMode === 'add' ? val + amt : val - amt;
+          const clamped = Math.max(0, Math.min(0xffffffff, out));
+          value = clamped.toString(16).toUpperCase().padStart(8, '0');
+        }
+      } else if (transformType === 'Sequential Fill') {
+        const start = parseInt(seqStart, 10) || 0;
+        const inc = parseInt(seqIncrement, 10) || 0;
+        const out = start + inc * i;
+        const clamped = Math.max(0, Math.min(0xffffffff, out));
+        value = clamped.toString(16).toUpperCase().padStart(8, '0');
+      } else if (transformType === 'Set Fixed Value') {
+        value = fixedValue.toUpperCase();
+      } else if (transformType === 'Shift Keys') {
+        const shift = parseInt(shiftAmount, 10) || 0;
+        const dec = parseInt(key.split('.')[1], 10);
+        const newIdx = shiftDir === 'up' ? dec + shift : dec - shift;
+        key = `${layerKey}.${String(newIdx).padStart(4, '0')}`;
+      }
+      const dec = parseInt(key.split('.')[1], 10);
+      const hex = parseInt(value, 16);
+      const offset = dec - (isNaN(hex) ? 0 : hex);
+      newRows[idx] = { key, value, offset };
+    });
+    setRows(newRows);
+  };
+
   const handleSave = () => {
     onSave(rows.map(r => ({ key: r.key, value: r.value })));
     onClose();
   };
 
-  const keyRegex = /^\d{2}\.\d{4}$/;
-  const valRegex = /^[0-9A-Fa-f]{8}$/;
   const { query, matchSet, currentResult } = useSearch() || {};
   const { highlight, currentHighlight } = useHighlightColors();
+
+  const preview = useMemo(() => {
+    if (selected.length < 2) return [];
+    const indices = [...selected];
+    if (transformType === 'Sequential Fill' && seqOrder === 'key') {
+      indices.sort((a, b) => {
+        const aVal = parseInt(rows[a].key.split('.')[1], 10);
+        const bVal = parseInt(rows[b].key.split('.')[1], 10);
+        return aVal - bVal;
+      });
+    }
+    const result = [];
+    indices.forEach((idx, i) => {
+      const row = rows[idx];
+      let newKey = row.key;
+      let newValue = row.value;
+      if (transformType === 'Adjust Values') {
+        if (!(skipZero && row.offset === 0)) {
+          const val = parseInt(row.value, 16) || 0;
+          const amt = parseInt(adjustAmount, 10) || 0;
+          const out = adjustMode === 'add' ? val + amt : val - amt;
+          const clamped = Math.max(0, Math.min(0xffffffff, out));
+          newValue = clamped.toString(16).toUpperCase().padStart(8, '0');
+        }
+      } else if (transformType === 'Sequential Fill') {
+        const start = parseInt(seqStart, 10) || 0;
+        const inc = parseInt(seqIncrement, 10) || 0;
+        const out = start + inc * i;
+        const clamped = Math.max(0, Math.min(0xffffffff, out));
+        newValue = clamped.toString(16).toUpperCase().padStart(8, '0');
+      } else if (transformType === 'Set Fixed Value') {
+        newValue = fixedValue.toUpperCase();
+      } else if (transformType === 'Shift Keys') {
+        const shift = parseInt(shiftAmount, 10) || 0;
+        const dec = parseInt(row.key.split('.')[1], 10);
+        const newIdx = shiftDir === 'up' ? dec + shift : dec - shift;
+        newKey = `${layerKey}.${String(newIdx).padStart(4, '0')}`;
+      }
+      const dec = parseInt(newKey.split('.')[1], 10);
+      const hex = parseInt(newValue, 16);
+      const offset = dec - (isNaN(hex) ? 0 : hex);
+      result.push({ old: row, newKey, newValue, newOffset: offset });
+    });
+    return result;
+  }, [selected, rows, transformType, adjustMode, adjustAmount, skipZero, seqStart, seqIncrement, seqOrder, fixedValue, shiftDir, shiftAmount, layerKey]);
+
+  const hasShiftConflict = useMemo(() => {
+    if (transformType !== 'Shift Keys' || selected.length < 2) return false;
+    const indices = selected;
+    const otherKeys = rows
+      .filter((_, i) => !indices.includes(i))
+      .map(r => r.key);
+    const newKeys = indices.map(idx => {
+      const dec = parseInt(rows[idx].key.split('.')[1], 10);
+      const amt = parseInt(shiftAmount, 10) || 0;
+      const newIdx = shiftDir === 'up' ? dec + amt : dec - amt;
+      return `${layerKey}.${String(newIdx).padStart(4, '0')}`;
+    });
+    const dup = new Set();
+    for (const k of newKeys) {
+      if (dup.has(k) || otherKeys.includes(k)) return true;
+      dup.add(k);
+    }
+    return false;
+  }, [transformType, selected, rows, shiftAmount, shiftDir, layerKey]);
+
+  const inputsValid = useMemo(() => {
+    if (selected.length < 2) return false;
+    if (transformType === 'Adjust Values') {
+      return !Number.isNaN(parseInt(adjustAmount, 10));
+    }
+    if (transformType === 'Sequential Fill') {
+      return (
+        !Number.isNaN(parseInt(seqStart, 10)) &&
+        !Number.isNaN(parseInt(seqIncrement, 10))
+      );
+    }
+    if (transformType === 'Set Fixed Value') {
+      return valRegex.test(fixedValue);
+    }
+    if (transformType === 'Shift Keys') {
+      return (
+        !Number.isNaN(parseInt(shiftAmount, 10)) &&
+        !hasShiftConflict
+      );
+    }
+    return false;
+  }, [transformType, adjustAmount, seqStart, seqIncrement, fixedValue, shiftAmount, hasShiftConflict, selected.length]);
 
   return (
     <Dialog
@@ -233,6 +396,187 @@ export default function EntryEditModal({
           >
             Delete Selected
           </Button>
+
+          <Box sx={{ mt: 2, p: 1, border: 1, borderColor: selected.length >= 2 ? 'primary.main' : 'divider', borderRadius: 1 }}>
+            <Typography variant="subtitle1" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              {`Transform Selected Entries (${selected.length} selected)`}
+              <Tooltip title="Apply batch changes to the selected entries">
+                <InfoOutlinedIcon fontSize="small" />
+              </Tooltip>
+            </Typography>
+            <Collapse in={selected.length >= 2}>
+              <FormControl fullWidth size="small" sx={{ mt: 1 }}>
+                <InputLabel id="tt-label">Transformation Type</InputLabel>
+                <Select
+                  labelId="tt-label"
+                  value={transformType}
+                  label="Transformation Type"
+                  onChange={e => setTransformType(e.target.value)}
+                >
+                  <MenuItem value="Adjust Values">Adjust Values - Add or subtract from hex values</MenuItem>
+                  <MenuItem value="Sequential Fill">Sequential Fill - Auto-number entries</MenuItem>
+                  <MenuItem value="Set Fixed Value">Set Fixed Value - Apply same value</MenuItem>
+                  <MenuItem value="Shift Keys">Shift Keys - Renumber the key indices</MenuItem>
+                </Select>
+              </FormControl>
+
+              {transformType === 'Adjust Values' && (
+                <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <RadioGroup
+                    row
+                    value={adjustMode}
+                    onChange={e => setAdjustMode(e.target.value)}
+                  >
+                    <FormControlLabel value="add" control={<Radio />} label="Add" />
+                    <FormControlLabel value="subtract" control={<Radio />} label="Subtract" />
+                  </RadioGroup>
+                  <TextField
+                    label="Amount"
+                    type="number"
+                    size="small"
+                    value={adjustAmount}
+                    onChange={e => setAdjustAmount(e.target.value)}
+                    InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                    helperText={`= 0x${(parseInt(adjustAmount, 10) || 0)
+                      .toString(16)
+                      .toUpperCase()
+                      .padStart(8, '0')}`}
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={skipZero}
+                        onChange={e => setSkipZero(e.target.checked)}
+                      />
+                    }
+                    label="Skip entries with zero offset"
+                  />
+                </Box>
+              )}
+
+              {transformType === 'Sequential Fill' && (
+                <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <TextField
+                    label="Starting value"
+                    type="number"
+                    size="small"
+                    value={seqStart}
+                    onChange={e => setSeqStart(e.target.value)}
+                    helperText={`= 0x${(parseInt(seqStart, 10) || 0)
+                      .toString(16)
+                      .toUpperCase()
+                      .padStart(8, '0')}`}
+                    InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                  />
+                  <TextField
+                    label="Increment"
+                    type="number"
+                    size="small"
+                    value={seqIncrement}
+                    onChange={e => setSeqIncrement(e.target.value)}
+                    helperText={`= 0x${(parseInt(seqIncrement, 10) || 0)
+                      .toString(16)
+                      .toUpperCase()
+                      .padStart(8, '0')}`}
+                    InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                  />
+                  <FormControl fullWidth size="small">
+                    <InputLabel id="order-label">Order</InputLabel>
+                    <Select
+                      labelId="order-label"
+                      value={seqOrder}
+                      label="Order"
+                      onChange={e => setSeqOrder(e.target.value)}
+                    >
+                      <MenuItem value="selection">By selection order</MenuItem>
+                      <MenuItem value="key">By key order</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Box>
+              )}
+
+              {transformType === 'Set Fixed Value' && (
+                <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <TextField
+                    label="Hex Value"
+                    value={fixedValue}
+                    onChange={e => setFixedValue(e.target.value.toUpperCase())}
+                    size="small"
+                    error={!valRegex.test(fixedValue)}
+                    helperText="8-digit hex value"
+                    InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                  />
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    <Button variant="outlined" size="small" onClick={() => setFixedValue('00000000')}>
+                      All zeros
+                    </Button>
+                    <Button variant="outlined" size="small" onClick={() => setFixedValue('FFFFFFFF')}>
+                      All F's
+                    </Button>
+                  </Box>
+                </Box>
+              )}
+
+              {transformType === 'Shift Keys' && (
+                <Box sx={{ mt: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  <RadioGroup
+                    row
+                    value={shiftDir}
+                    onChange={e => setShiftDir(e.target.value)}
+                  >
+                    <FormControlLabel value="up" control={<Radio />} label="Shift up" />
+                    <FormControlLabel value="down" control={<Radio />} label="Shift down" />
+                  </RadioGroup>
+                  <TextField
+                    label="Amount"
+                    type="number"
+                    size="small"
+                    value={shiftAmount}
+                    onChange={e => setShiftAmount(e.target.value)}
+                    InputProps={{ sx: { fontFamily: '"JetBrains Mono", monospace' } }}
+                  />
+                  {hasShiftConflict && (
+                    <Typography variant="caption" color="error.main">
+                      Key conflict detected
+                    </Typography>
+                  )}
+                </Box>
+              )}
+
+              <Accordion sx={{ mt: 1 }} expanded={previewOpen} onChange={() => setPreviewOpen(!previewOpen)}>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2">Preview Changes</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  {preview.slice(0, 5).map((p, i) => {
+                    const diff = Math.abs(p.newOffset) - Math.abs(p.old.offset);
+                    const color = diff < 0 ? 'success.main' : diff > 0 ? 'warning.main' : 'text.primary';
+                    return (
+                      <Box key={i} sx={{ display: 'flex', justifyContent: 'space-between', fontFamily: '"JetBrains Mono", monospace', color }}>
+                        <Box>{p.old.key}</Box>
+                        <Box>{p.old.value} → {p.newValue}</Box>
+                      </Box>
+                    );
+                  })}
+                  {preview.length > 5 && (
+                    <Typography variant="caption" sx={{ mt: 1 }}>
+                      {`... and ${preview.length - 5} more entries`}
+                    </Typography>
+                  )}
+                </AccordionDetails>
+              </Accordion>
+
+              <Button
+                fullWidth
+                variant="contained"
+                sx={{ mt: 2 }}
+                disabled={!inputsValid}
+                onClick={applyTransform}
+              >
+                {`Apply to ${selected.length} entries`}
+              </Button>
+            </Collapse>
+          </Box>
         </Box>
       </Box>
       <DialogActions>


### PR DESCRIPTION
## Summary
- extend EntryEditModal with a transformation panel for batch editing
- support adjusting values, sequential fill, fixed value, and key shifting
- include preview and validation logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a49769cd0832f98036f5c972f2bbe