### PR TITLE
Fix search highlight overriding selection

### DIFF
--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -33,10 +33,10 @@ export default function EntryList({
           mb: 0.5,
           borderRadius: 1,
           transition: 'background-color 0.3s',
-          '&.Mui-selected': { bgcolor: 'action.selected' },
           ...(matchSet?.has(item.key) && { bgcolor: highlight }),
           ...(query && !matchSet?.has(item.key) && { opacity: 0.7 }),
           ...(currentResult?.key === item.key && { bgcolor: currentHighlight }),
+          '&.Mui-selected': { bgcolor: 'action.selected' },
         }}
       >
         <Box sx={{ display: 'flex', width: '100%' }}>

--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -277,12 +277,12 @@ export default function EntryEditModal({
                   py: 0,
                   minHeight: 0,
                   borderRadius: 1,
-                  bgcolor: selected.includes(i) ? 'action.selected' : undefined,
                   transition: 'background-color 0.3s',
                   '&:hover': { bgcolor: 'action.hover' },
                   ...(isMatch && { bgcolor: highlight }),
                   ...(query && !isMatch && { opacity: 0.7 }),
                   ...(isCurrent && { bgcolor: currentHighlight }),
+                  bgcolor: selected.includes(i) ? 'action.selected' : undefined,
                 }}
               >
               <TextField

--- a/client/src/components/Editor/LayerList.jsx
+++ b/client/src/components/Editor/LayerList.jsx
@@ -52,10 +52,10 @@ const LayerList = ({ layers = [], selected, onSelect, onDelete, onError }) => {
             mb: 0.5,
             borderRadius: 1,
             transition: 'background-color 0.3s',
-            '&.Mui-selected': { bgcolor: 'action.selected' },
             ...(isMatch && { bgcolor: highlight }),
             ...(query && !isMatch && { opacity: 0.7 }),
             ...(isCurrent && { bgcolor: currentHighlight }),
+            '&.Mui-selected': { bgcolor: 'action.selected' },
           }}
         >
           <ListItemText


### PR DESCRIPTION
## Summary
- ensure selection colors override search highlight when clicking entries

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a4e939968832fb687090d4e452d0f