### PR TITLE
Isolate search context in entry editor

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -24,9 +24,9 @@ import {
   Collapse,
   Tooltip,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import useHighlightColors from '../../utils/useHighlightColors.js';
-import { useSearch } from '../../hooks/useSearch.jsx';
+import { SearchProvider, useSearch } from '../../hooks/useSearch.jsx';
 import AppToolbar from '../Layout/AppToolbar.jsx';
 import SearchField from '../Common/SearchField.jsx';
 
@@ -225,15 +225,34 @@ export default function EntryEditModal({
 
   const keyRegex = /^\d{2}\.\d{4}$/;
   const valRegex = /^[0-9A-Fa-f]{8}$/;
-  const { query, matchSet, currentResult } = useSearch() || {};
-  const { highlight, currentHighlight } = useHighlightColors();
+  const searchIndex = useMemo(
+    () =>
+      rows.map(r => ({
+        type: type.toLowerCase(),
+        key: r.key,
+        value: r.value,
+        layerKey,
+        text: `${r.key} ${r.value}`,
+      })),
+    [rows, type, layerKey]
+  );
 
-  return (
-    <Dialog
+  const ModalContent = () => {
+    const { query, matchSet, currentResult } = useSearch() || {};
+    const { highlight, currentHighlight } = useHighlightColors();
+
+    return (
+      <Dialog
         fullScreen
         open={open}
         onClose={onClose}
-        PaperProps={{ sx: { display: 'flex', flexDirection: 'column', bgcolor: 'background.default' } }}
+        PaperProps={{
+          sx: {
+            display: 'flex',
+            flexDirection: 'column',
+            bgcolor: 'background.default',
+          },
+        }}
       >
         <AppToolbar position="relative">
           <Typography
@@ -536,6 +555,13 @@ export default function EntryEditModal({
           Save
         </Button>
       </DialogActions>
-    </Dialog>
+      </Dialog>
+    );
+  };
+
+  return (
+    <SearchProvider index={searchIndex} selectedLayer={layerKey}>
+      <ModalContent />
+    </SearchProvider>
   );
 }

--- a/client/src/hooks/useSearch.jsx
+++ b/client/src/hooks/useSearch.jsx
@@ -1,7 +1,7 @@
 /* eslint react-refresh/only-export-components: off */
 import { createContext, useContext, useState, useMemo, useEffect } from 'react';
 
-function buildSearchIndex({ layers = [], targets = {}, sources = {} }) {
+export function buildSearchIndex({ layers = [], targets = {}, sources = {} }) {
   const index = [];
   layers.forEach(l => {
     index.push({
@@ -43,13 +43,15 @@ export function SearchProvider({
   layers,
   targets,
   sources,
+  index: customIndex,
   selectedLayer,
   setSelectedLayer,
   children,
 }) {
   const index = useMemo(
-    () => buildSearchIndex({ layers, targets, sources }),
-    [layers, targets, sources]
+    () =>
+      customIndex || buildSearchIndex({ layers, targets, sources }),
+    [customIndex, layers, targets, sources]
   );
 
   const [query, setQuery] = useState('');


### PR DESCRIPTION
## Summary
- export `buildSearchIndex`
- allow `SearchProvider` to accept a custom search index
- wrap entry edit modal in its own `SearchProvider`

## Testing
- `npm --prefix client ci`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a647173b4832fb8199c3005f916a1