### PR TITLE
Fix search highlight persistence in entry editor

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -61,9 +61,6 @@ function EntryEditModal({
   const [shiftDir, setShiftDir] = useState('up');
   const [shiftAmount, setShiftAmount] = useState(1);
 
-  const search = useSearch();
-
-
   useEffect(() => {
     if (open) {
       const mapped = entries.map(e => ({ ...e }));
@@ -79,11 +76,6 @@ function EntryEditModal({
     }
   }, [open, entries]);
 
-  useEffect(() => {
-    if (open && search && typeof search.setQuery === 'function') {
-      search.setQuery('');
-    }
-  }, [open, search]);
 
   const handleRowClick = (index, e) => {
     if (e.shiftKey && lastIndex !== null) {


### PR DESCRIPTION
## Summary
- keep search query when opening entry editor modal so results remain highlighted

## Testing
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a6bc9f704832f8310a5ca3b1c6499