### PR TITLE
Set shift as default operation

### DIFF
--- a/client/src/components/Editor/EntryEditModal.jsx
+++ b/client/src/components/Editor/EntryEditModal.jsx
@@ -45,7 +45,7 @@ function EntryEditModal({
   const [batchStart, setBatchStart] = useState(0);
   const [batchOffset, setBatchOffset] = useState(0);
 
-  const [transformType, setTransformType] = useState('adjust');
+  const [transformType, setTransformType] = useState('shift');
   const [adjustMode, setAdjustMode] = useState('add');
   const [adjustAmount, setAdjustAmount] = useState(0);
   const [skipZero, setSkipZero] = useState(false);
@@ -82,6 +82,7 @@ function EntryEditModal({
       setBatchQty(1);
       setSelected([]);
       setLastIndex(null);
+      setTransformType('shift');
     }
   }, [open, entries]);
 


### PR DESCRIPTION
## Summary
- change EntryEditModal default to `Shift Keys Up/Down`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686a8fba5534832f9253a820e0b8d544