### PR TITLE
Remove click effect from entry list items

### DIFF
--- a/client/src/components/Common/EntryList.jsx
+++ b/client/src/components/Common/EntryList.jsx
@@ -1,4 +1,4 @@
-import { Box, ListItemButton, Paper, Typography } from '@mui/material';
+import { Box, Paper, Typography } from '@mui/material';
 import useHighlightColors from '../../utils/useHighlightColors.js';
 import VirtualizedList from './VirtualizedList.jsx';
 import { useSearch } from '../../hooks/useSearch.jsx';
@@ -25,15 +25,15 @@ export default function EntryList({
 
   const defaultRow = (item, _i, style) => (
     <Box style={style} key={item.key}>
-      <ListItemButton
+      <Box
         sx={{
           height: '100%',
           minHeight: 0,
           py: 0,
+          px: 1,
           mb: 0.5,
           borderRadius: 1,
           transition: 'background-color 0.3s',
-          '&.Mui-selected': { bgcolor: 'action.selected' },
           ...(matchSet?.has(item.key) && { bgcolor: highlight }),
           ...(query && !matchSet?.has(item.key) && { opacity: 0.7 }),
           ...(currentResult?.key === item.key && { bgcolor: currentHighlight }),
@@ -53,7 +53,7 @@ export default function EntryList({
           {item.offset}
         </Box>
         </Box>
-      </ListItemButton>
+      </Box>
     </Box>
   );
 
@@ -75,7 +75,23 @@ export default function EntryList({
         {title}
       </Typography>
       {header !== undefined ? header : defaultHeader}
-      <Box sx={{ flex: 1, minHeight: 0 }}>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          '& > div > div': {
+            scrollbarWidth: 'thin',
+          },
+          '& > div > div::-webkit-scrollbar': {
+            width: 8,
+            height: 8,
+          },
+          '&:not(:hover) > div > div::-webkit-scrollbar': {
+            width: 0,
+            height: 0,
+          },
+        }}
+      >
         <VirtualizedList
           items={items}
           itemHeight={itemHeight}


### PR DESCRIPTION
## Summary
- remove click ripple by using a plain Box for entry rows
- add padding so keys and offsets aren't flush against the edges
- auto-hide scrollbars on layer/target/source lists

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b0bacc284832fb9880c6333e18649